### PR TITLE
 docs+chore: catalogo inicial de ADRs y complemento del bootstrap

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,17 @@
 - [ ] Cambio de infraestructura (IaC)
 - [ ] Runbook / documentacion SRE
 - [ ] Script operativo
+- [ ] Nuevo ADR o cambio en ADR existente
 - [ ] Documentacion general
+
+## Si es un ADR
+
+- **Numero y titulo**: ADR-XXXX —
+- **Area**: CI/CD | Infra | SRE | General
+- **Estado propuesto**: Propuesto | Aceptado
+- **Reemplaza a**: (si aplica) ADR-YYYY
+- **Toca IAM, OIDC, red, secretos o audit logs?**: Si / No
+  - Si si, requiere review de los **tres lideres de area**
 
 ## Impacto
 
@@ -24,5 +34,6 @@
 
 - [ ] He probado los cambios localmente o en un ambiente de prueba
 - [ ] La documentacion relevante ha sido actualizada
-- [ ] Los workflows modificados siguen la convencion de nombrado `stage--componente.yml`
+- [ ] Los workflows modificados siguen la convencion de nombrado `stage-componente.yml`
 - [ ] No se exponen secrets ni credenciales en el codigo
+- [ ] (Si es ADR) Esta incluido en el indice del area correspondiente

--- a/.github/workflows/_self-validation.yml
+++ b/.github/workflows/_self-validation.yml
@@ -1,0 +1,25 @@
+# =============================================================================
+# Workflow: _self-validation.yml
+# Tipo: workflow propio del repo Skorify_DevOps (no es reusable)
+# Propósito: validar el propio repo de plantillas — lint de YAML, valida
+#   sintaxis de los workflows reusables, lint de markdown de los ADRs.
+# Owner: equipo CI/CD — @steevensmelo
+# Estado: CASCARÓN — pendiente de implementación
+# =============================================================================
+#
+# Sugerencias de jobs cuando se implemente:
+# - actionlint para validar sintaxis de los workflows
+# - yamllint para los archivos pre-commit/*.yaml
+# - markdownlint para docs/adr/**/*.md
+# - verificación de que cada ADR aceptado tiene archivo + estado correcto
+
+name: self-validation
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# TODO: implementar jobs
+jobs: {}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,37 @@
+# CODEOWNERS — Skorify_DevOps
+#
+# Sintaxis: <patrón> <usuario o equipo>
+# Documentación oficial: buscar "About code owners" en docs.github.com
+#
+# Nota: este archivo usa handles individuales de los líderes de área.
+# Cuando se creen equipos (teams) dentro de la org `aws-ug-manizales`,
+# se pueden reemplazar estos handles por las referencias de equipo
+# (por ejemplo, @aws-ug-manizales/devops-cicd-leads) para incluir a
+# todo el subgrupo, no solo al líder.
+
+# Por defecto, cualquier cambio requiere aprobación del coordinador general
+*                                   @edisoncast
+
+# CI/CD — líder: Steevens Castañeda
+/.github/workflows/                 @steevensmelo
+/actions/                           @steevensmelo
+/pre-commit/                        @steevensmelo
+/docs/adr/ci-cd/                    @steevensmelo
+/docs/contributing.md               @steevensmelo
+
+# Infra — líder: Mateo Marín
+/iac/                               @Mateo454
+/docs/adr/infra/                    @Mateo454
+
+# SRE — líder: Michael Rivera
+/sre/                               @lmichaelrc
+/docs/adr/sre/                      @lmichaelrc
+
+# Onboarding y scripts — compartidos entre áreas
+/docs/onboarding/                   @steevensmelo @Mateo454
+/scripts/                           @steevensmelo @Mateo454 @lmichaelrc
+
+# ADRs generales y temas sensibles (IAM, OIDC, red, secretos, audit logs) requieren los tres líderes
+/docs/adr/0001-*                    @steevensmelo @Mateo454 @lmichaelrc
+/docs/adr/0002-*                    @steevensmelo @Mateo454 @lmichaelrc
+/docs/adr/0003-*                    @steevensmelo @Mateo454 @lmichaelrc

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 AWS User Group Manizales — Equipo Mediocampistas
+
+Por la presente se concede permiso, libre de cargos, a cualquier persona que
+obtenga una copia de este software y de los archivos de documentación asociados
+(el "Software"), a utilizar el Software sin restricción, incluyendo sin
+limitación los derechos a usar, copiar, modificar, fusionar, publicar,
+distribuir, sublicenciar, y/o vender copias del Software, y a permitir a las
+personas a las que se les proporcione el Software a hacer lo mismo, sujeto a
+las siguientes condiciones:
+
+El aviso de copyright anterior y este aviso de permiso se incluirán en todas
+las copias o partes sustanciales del Software.
+
+EL SOFTWARE SE PROPORCIONA "COMO ESTÁ", SIN GARANTÍA DE NINGÚN TIPO, EXPRESA O
+IMPLÍCITA, INCLUYENDO PERO NO LIMITADO A GARANTÍAS DE COMERCIALIZACIÓN,
+IDONEIDAD PARA UN PROPÓSITO PARTICULAR Y NO INFRACCIÓN. EN NINGÚN CASO LOS
+AUTORES O TITULARES DEL COPYRIGHT SERÁN RESPONSABLES POR NINGUNA RECLAMACIÓN,
+DAÑOS U OTRAS RESPONSABILIDADES, YA SEA EN UNA ACCIÓN DE CONTRATO, AGRAVIO O
+CUALQUIER OTRO MOTIVO, DERIVADAS DE, FUERA DE O EN CONEXIÓN CON EL SOFTWARE O
+SU USO U OTRO TIPO DE ACCIONES EN EL SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Workflows reutilizables que los repositorios de Frontend, Backend y Datos consum
 ```yaml
 jobs:
   lint:
-    uses: skorify-org/skorify-shared-workflows/.github/workflows/lint--frontend.yml@v1
+    uses: aws-ug-manizales/Skorify_DevOps/.github/workflows/lint-frontend.yml@v1
     with:
       node-version: '20'
     secrets: inherit
@@ -37,7 +37,7 @@ Pasos atomicos reutilizables que se usan dentro de los workflows (setup de Node,
 
 ```yaml
 steps:
-  - uses: skorify-org/skorify-shared-workflows/actions/setup-node@v1
+  - uses: aws-ug-manizales/Skorify_DevOps/actions/setup-node@v1
     with:
       node-version: '20'
 ```
@@ -56,7 +56,13 @@ Runbooks de incidentes, definiciones de SLOs, configuraciones de alertas/dashboa
 
 ### `docs/` - Documentacion
 
-Guias de uso de los shared workflows, guia de contribucion, referencia de ambientes y politica de secrets.
+Guias de uso de los shared workflows, guia de contribucion, decisiones arquitectonicas (ADRs) y onboarding por repo de aplicacion.
+
+Subcarpetas relevantes:
+
+- [`docs/adr/`](./docs/adr/) — Architecture Decision Records (formato Nygard, en espanol)
+- [`docs/onboarding/`](./docs/onboarding/) — guias para conectar cada repo de aplicacion a las plantillas
+- [`docs/contributing.md`](./docs/contributing.md) — proceso de contribucion al repo
 
 ## Ambientes
 
@@ -65,3 +71,29 @@ Guias de uso de los shared workflows, guia de contribucion, referencia de ambien
 | DEV | `develop` | Integracion y feedback rapido |
 | Staging | `release/vX.X` | Pruebas completas pre-produccion |
 | PROD | `main` | Produccion con aprobacion manual |
+
+## Equipo DevOps "Mediocampistas"
+
+| Area | Lider | Alcance |
+|------|-------|---------|
+| **CI/CD** | Steevens Castaneda (@steevensmelo) | GitHub Actions, pipelines, plantillas, secret scanning, SCA |
+| **Infra** | Mateo Marin (@Mateo454) | IaC (CDK + SAM), AWS, IAM, OIDC, red, KMS, ambientes |
+| **SRE** | Michael Rivera (@lmichaelrc) | Observabilidad (Datadog), logs, metricas, traces, audit logging |
+
+**Coordinacion general**: Edison Castro (@edisoncast).
+
+> El area de Seguridad fue disuelta y sus responsabilidades se redistribuyeron entre las tres areas. Ver [ADR-0002 general](./docs/adr/0002-redistribucion-responsabilidades-seguridad.md).
+
+## ADRs
+
+Toda decision tecnica significativa se documenta como ADR antes de implementarse:
+
+1. Crear ADR como `Propuesto` via Pull Request siguiendo la [plantilla Nygard](./docs/adr/0000-template.md).
+2. Aprobacion: **2 revisores del area duena + 1 revisor cruzado** de otra area. ADRs sensibles (IAM, OIDC, red, secretos, audit logs) requieren los **tres lideres de area**.
+3. Los ADRs aceptados no se editan; cambios → ADR nuevo que `Reemplaza por: ADR-XXXX`.
+
+Ver el [indice general de ADRs](./docs/adr/) y los indices por area: [CI/CD](./docs/adr/ci-cd/), [Infra](./docs/adr/infra/), [SRE](./docs/adr/sre/).
+
+## Convencion de commits
+
+Conventional Commits: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `ci:`, `adr:` (este ultimo para PRs que añaden o cambian un ADR).

--- a/actions/notify-slack/action.yml
+++ b/actions/notify-slack/action.yml
@@ -1,0 +1,30 @@
+# =============================================================================
+# Composite action: notify-slack
+# Propósito: notificar resultado de un workflow al canal de Slack/Discord
+#   correspondiente al equipo o ambiente.
+# Owner: equipo CI/CD — @steevensmelo
+# Estado: CASCARÓN — pendiente de implementación
+# =============================================================================
+#
+# Nota: el nombre asume Slack pero la herramienta exacta se decidirá por el
+# equipo de comunicación del proyecto. Ajustar el nombre si se elige Discord
+# u otra plataforma.
+
+name: notify-slack
+description: Envía notificación de resultado de workflow al canal correspondiente.
+
+inputs:
+  status:
+    description: Resultado del workflow (success, failure, cancelled).
+    required: true
+  channel:
+    description: Canal destino.
+    required: true
+  # TODO: declarar inputs adicionales
+
+runs:
+  using: composite
+  steps:
+    # TODO: implementar
+    - shell: bash
+      run: echo "TODO: implementar notify-slack"

--- a/actions/run-eslint/action.yml
+++ b/actions/run-eslint/action.yml
@@ -1,0 +1,25 @@
+# =============================================================================
+# Composite action: run-eslint
+# Propósito: ejecutar ESLint con configuración del repo y reportar resultados.
+# Owner: equipo CI/CD — @steevensmelo
+# Estado: CASCARÓN — pendiente de implementación
+# =============================================================================
+#
+# Referencia: ADR-CICD-0005 (stage de Linting & formatting en MVP)
+
+name: run-eslint
+description: Ejecuta ESLint con la configuración del repo consumidor.
+
+inputs:
+  working-directory:
+    description: Directorio donde correr eslint.
+    required: false
+    default: '.'
+  # TODO: declarar inputs adicionales (max-warnings, format, etc.)
+
+runs:
+  using: composite
+  steps:
+    # TODO: implementar (eslint con reporter compatible con GitHub annotations)
+    - shell: bash
+      run: echo "TODO: implementar run-eslint"

--- a/actions/run-trivy/action.yml
+++ b/actions/run-trivy/action.yml
@@ -1,0 +1,29 @@
+# =============================================================================
+# Composite action: run-trivy
+# Propósito: escaneo SCA con Trivy sobre dependencias del proyecto.
+# Owner: equipo CI/CD — @steevensmelo
+# Estado: CASCARÓN — pendiente de implementación
+# =============================================================================
+#
+# Referencia: ADR-CICD-0005 (stages MVP — SCA es uno de ellos)
+
+name: run-trivy
+description: Ejecuta Trivy para escanear vulnerabilidades en dependencias.
+
+inputs:
+  scan-type:
+    description: Tipo de escaneo (fs, image, repo).
+    required: false
+    default: fs
+  severity:
+    description: Severidades a reportar como falla.
+    required: false
+    default: 'HIGH,CRITICAL'
+  # TODO: declarar inputs adicionales (ignore-unfixed, format, etc.)
+
+runs:
+  using: composite
+  steps:
+    # TODO: implementar (aquasecurity/trivy-action)
+    - shell: bash
+      run: echo "TODO: implementar run-trivy"

--- a/actions/setup-aws-credentials/action.yml
+++ b/actions/setup-aws-credentials/action.yml
@@ -1,0 +1,29 @@
+# =============================================================================
+# Composite action: setup-aws-credentials
+# Propósito: configurar credenciales AWS vía OIDC para el ambiente especificado.
+# Owner: equipo CI/CD — @steevensmelo (con revisión de Infra para los roles)
+# Estado: CASCARÓN — pendiente de implementación
+# =============================================================================
+#
+# Referencia: ADR-INFRA-0005 (autenticación GitHub→AWS vía OIDC).
+# Decisión sensible: requiere aprobación de los 3 líderes (toca IAM).
+
+name: setup-aws-credentials
+description: Configura credenciales temporales AWS vía OIDC para un ambiente.
+
+inputs:
+  environment:
+    description: Ambiente destino (dev, stg, prd).
+    required: true
+  aws-region:
+    description: Región AWS.
+    required: false
+    default: us-east-1
+  # TODO: declarar input role-to-assume o resolverlo desde environment
+
+runs:
+  using: composite
+  steps:
+    # TODO: implementar (aws-actions/configure-aws-credentials con role-to-assume)
+    - shell: bash
+      run: echo "TODO: implementar setup-aws-credentials para ${{ inputs.environment }}"

--- a/actions/setup-node/action.yml
+++ b/actions/setup-node/action.yml
@@ -1,0 +1,31 @@
+# =============================================================================
+# Composite action: setup-node
+# Propósito: instalar Node.js con caching consistente entre repos.
+# Owner: equipo CI/CD — @steevensmelo
+# Estado: CASCARÓN — pendiente de implementación
+# =============================================================================
+#
+# Nota sobre package manager: Skorify_Frontend usa yarn; Skorify_Backend y
+# Skorify_Data usan pnpm. La implementación debe soportar al menos pnpm + yarn,
+# o se crean dos actions hermanas. Ver decisión cruzada en ADR-CICD-0010.
+
+name: setup-node
+description: Instala Node.js con cache habilitado para el package manager indicado.
+
+inputs:
+  node-version:
+    description: Versión de Node.js (LTS por defecto).
+    required: false
+    default: '20'
+  package-manager:
+    description: Package manager (pnpm | yarn | npm).
+    required: false
+    default: pnpm
+  # TODO: declarar inputs adicionales (working-directory, frozen-lockfile, etc.)
+
+runs:
+  using: composite
+  steps:
+    # TODO: implementar steps (actions/setup-node, pnpm/action-setup o yarn cache, cache)
+    - shell: bash
+      run: echo "TODO: implementar setup-node con package-manager=${{ inputs.package-manager }}"

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,53 @@
+# ADR-NNNN: Título corto y descriptivo
+
+> Plantilla basada en el formato propuesto por Michael Nygard. Copia este archivo,
+> renómbralo siguiendo la convención `NNNN-titulo-en-kebab-case.md` y reemplaza
+> los marcadores. **No edites esta plantilla**.
+
+- **Estado**: Propuesto <!-- Propuesto | Aceptado | Rechazado | Obsoleto | Reemplazado por ADR-XXXX -->
+- **Fecha**: YYYY-MM-DD
+- **Área**: CI/CD <!-- CI/CD | Infra | SRE | General -->
+- **Autores**: @usuario
+- **Aprobadores**: @lider-area, @lider-cruzado, @lider-cruzado-2
+- **Reemplaza a**: (si aplica) ADR-YYYY
+- **Reemplazado por**: (si aplica) ADR-ZZZZ
+
+## Contexto
+
+Describe la situación, el problema a resolver, las fuerzas en juego y las
+restricciones técnicas, organizacionales o de negocio que motivan la decisión.
+
+Sé específico:
+
+- ¿Qué problema concreto estamos resolviendo?
+- ¿Qué pasa si no decidimos nada?
+- ¿Qué restricciones limitan las opciones? (presupuesto, timeline, perfil del
+  equipo, dependencias externas, decisiones previas)
+- Si la decisión depende de otra decisión, enlaza el ADR correspondiente.
+
+## Decisión
+
+Una o dos frases en voz activa y afirmativa que dejen sin ambigüedad qué se
+decidió hacer. **No** "vamos a evaluar"; **sí** "usamos X".
+
+Si la decisión incluye varios puntos, listálos en bullets numerados.
+
+## Consecuencias
+
+### Positivas
+
+- ...
+
+### Negativas / Trade-offs
+
+- ...
+
+### Neutrales / Riesgos a monitorear
+
+- ...
+
+## Notas adicionales (opcional)
+
+- Enlaces a documentación externa, RFCs, prototipos, benchmarks
+- Comentarios sobre la implementación
+- Pendientes / decisiones diferidas relacionadas

--- a/docs/adr/0001-adopcion-formato-adr.md
+++ b/docs/adr/0001-adopcion-formato-adr.md
@@ -1,0 +1,58 @@
+# ADR-0001: Adopción del formato Nygard y proceso de ADRs
+
+- **Estado**: Aceptado
+- **Fecha**: 2026-04-26
+- **Área**: General
+- **Autores**: @edisoncast (Edison Castro, coordinador general)
+- **Aprobadores**: @steevensmelo (Steevens Castañeda, CI/CD), @Mateo454 (Mateo Marín, Infra), @lmichaelrc (Michael Rivera, SRE)
+
+## Contexto
+
+El equipo DevOps "Mediocampistas" toma decisiones técnicas que afectan a los tres equipos de aplicación (frontend, backend, data). El equipo es heterogéneo: tres sub-líderes con experiencia y la mayoría de integrantes son estudiantes en su primer proyecto de software. Las decisiones que se tomen en abril de 2026 deben ser entendibles, auditables y reversibles para personas que se incorporen meses después o que rotan entre áreas.
+
+Sin un mecanismo formal de registro:
+
+- Las decisiones quedan dispersas en mensajes de WhatsApp y reuniones.
+- Quien llega nuevo no entiende **por qué** se eligió X sobre Y.
+- Las reversiones se hacen sin documentar la nueva motivación.
+- Los estudiantes pierden una oportunidad de aprendizaje sobre gobernanza técnica.
+
+Necesitamos un formato simple, en español, que cualquier integrante del equipo pueda leer y escribir sin formación previa.
+
+## Decisión
+
+Adoptamos el formato **Nygard** para todas las decisiones arquitectónicas del equipo DevOps. Cada ADR contiene como mínimo: Estado, Fecha, Área, Autores, Aprobadores, Contexto, Decisión y Consecuencias.
+
+Reglas del proceso:
+
+1. **Propuesta vía Pull Request**: cualquier integrante puede proponer un ADR creando un PR con el archivo en `docs/adr/{area}/NNNN-titulo.md` y estado `Propuesto`.
+2. **Aprobación estándar**: 2 personas del área dueña + 1 persona cruzada de otra área.
+3. **Aprobación reforzada**: ADRs que toquen IAM, OIDC, red, secretos o audit logs requieren los **tres líderes de área** (Steevens Castañeda, Mateo Marín, Michael Rivera). Esto compensa la disolución del área de Seguridad — ver ADR-0002.
+4. **Mergeo**: al mergearse, el estado pasa a `Aceptado`.
+5. **Inmutabilidad**: los ADRs aceptados no se editan. Cambios sustanciales → ADR nuevo con `Reemplaza por: ADR-XXXX`; el viejo se marca `Obsoleto` con un commit que solo cambia el campo Estado.
+6. **Idioma**: todo el contenido en español. Nombres de archivos en kebab-case y términos técnicos reservados en inglés.
+7. **Numeración**: los ADRs generales (transversales) se numeran en `docs/adr/`. Los específicos de área se numeran independientemente en `docs/adr/ci-cd/`, `docs/adr/infra/` y `docs/adr/sre/`.
+
+## Consecuencias
+
+### Positivas
+
+- Trazabilidad histórica de cada decisión técnica.
+- Onboarding más rápido para nuevos integrantes.
+- Ejercicio pedagógico para los estudiantes: aprenden a escribir y revisar ADRs, una práctica habitual en la industria.
+- El requisito de cross-review evita decisiones tomadas en silos por una sola área.
+
+### Negativas / Trade-offs
+
+- Overhead de proceso para decisiones pequeñas. Mitigación: reservar ADRs para decisiones que tengan impacto cross-team o sean difíciles de revertir.
+- La aprobación reforzada (3 líderes) puede ralentizar decisiones sensibles. Aceptamos el costo a cambio de evitar agujeros de gobernanza tras la disolución del área de Seguridad.
+
+### Neutrales / Riesgos a monitorear
+
+- Si los ADRs se vuelven una formalidad sin discusión real, perdemos el valor. Cada ADR debe tener sección **Contexto** suficientemente detallada para que el lector entienda por qué la decisión no es trivial.
+- Los ADRs `Propuesto` que queden olvidados generan deuda. Revisar pendientes en cada retrospectiva del equipo.
+
+## Notas adicionales
+
+- Plantilla canónica: [`0000-template.md`](./0000-template.md).
+- Formato Nygard original (referencia histórica): post de Michael Nygard "Documenting Architecture Decisions" (2011). Buscable como referencia de la industria.

--- a/docs/adr/0002-redistribucion-responsabilidades-seguridad.md
+++ b/docs/adr/0002-redistribucion-responsabilidades-seguridad.md
@@ -1,0 +1,68 @@
+# ADR-0002: Redistribución de responsabilidades tras disolución del área de Seguridad
+
+- **Estado**: Aceptado
+- **Fecha**: 2026-04-26
+- **Área**: General
+- **Autores**: @edisoncast (Edison Castro, coordinador general)
+- **Aprobadores**: @steevensmelo (Steevens Castañeda, CI/CD), @Mateo454 (Mateo Marín, Infra), @lmichaelrc (Michael Rivera, SRE)
+
+## Contexto
+
+El equipo DevOps "Mediocampistas" se diseñó originalmente con cuatro áreas: CI/CD, Infra, SRE y **Seguridad**. El área de Seguridad sería responsable de OIDC, IAM, ejercicios de red team y revisión de aspectos de seguridad transversales.
+
+Antes del arranque del proyecto, el sub-líder designado para Seguridad dejó de estar disponible y no fue reemplazado. Tenemos un timeline ajustado para entregar y no podemos esperar a reclutar un nuevo líder ni promover internamente sin afectar la entrega.
+
+Si dejamos las responsabilidades de seguridad sin dueño explícito:
+
+- Nadie configura OIDC, IAM ni KMS → el resto de áreas se bloquea.
+- El secret scanning, SCA y SAST no se incorporan a los pipelines.
+- Quedamos sin revisor con perspectiva de seguridad para cambios sensibles.
+- Existe el riesgo de que cada área asuma que "alguien más" se encargará.
+
+## Decisión
+
+Disolvemos formalmente el área de Seguridad y redistribuimos sus responsabilidades entre las tres áreas restantes según la siguiente tabla:
+
+| Responsabilidad original (Seguridad) | Reasignada a | Notas |
+|--------------------------------------|--------------|-------|
+| OIDC GitHub→AWS | Infra | Trust policies, identity provider |
+| IAM (roles, policies, boundaries) | Infra | Roles por ambiente, principio de menor privilegio |
+| Network security (VPC, SG, NACL) | Infra | Si aplica al stack final |
+| KMS y encriptación at-rest | Infra | Llaves por ambiente |
+| Secret scanning en código (gitleaks) | CI/CD | Hook pre-commit + job en CI |
+| SCA (vulnerabilidades en dependencias) | CI/CD | Trivy en stage SCA |
+| SAST (vulnerabilidades en código) | CI/CD | Semgrep, fase 2 |
+| Audit logging (CloudTrail) | SRE | Integrado a Datadog para visibilidad runtime |
+| Gestión de secretos runtime | Infra (provisioning) + SRE (rotación y monitoreo) | SSM/Secrets Manager |
+| Gestión de secretos CI | CI/CD | GitHub Environments secrets |
+
+**Quedan fuera de alcance MVP** (documentadas como riesgo conocido):
+
+- **Red team / pentesting activo**: no realista para el timeline ni el perfil del equipo (mayoría estudiantes). Mitigación: SCA + SAST automatizado cubre defensiva básica.
+- **DAST** (dynamic application security testing): se evaluará en fase 2.
+- **Compliance formal** (PCI/GDPR/SOC2): no aplica al alcance del proyecto.
+
+**Compensación de gobernanza**: ADRs que toquen IAM, OIDC, red, secretos o audit logs requieren aprobación de los **tres líderes de área**, no solo del área dueña + 1 cruzado. Esto reemplaza la revisión que habría hecho el líder de Seguridad.
+
+## Consecuencias
+
+### Positivas
+
+- Cada responsabilidad de seguridad tiene un dueño explícito y documentado.
+- Las áreas absorbentes ya tienen contexto natural: IAM/OIDC encajan con quien gestiona AWS; secret scanning encaja con quien gestiona pipelines.
+- La regla de cross-review reforzado mantiene tres pares de ojos en cambios sensibles.
+
+### Negativas / Trade-offs
+
+- Sin un líder de seguridad dedicado, perdemos profundidad técnica en temas como threat modeling o revisión de código con foco offensive.
+- La carga de los tres líderes aumenta porque deben revisar todos los ADRs sensibles.
+- Red team queda explícitamente fuera, lo cual deja una superficie de ataque sin probar.
+
+### Neutrales / Riesgos a monitorear
+
+- **Riesgo**: que ningún área se sienta dueña real de la seguridad y los temas se posterguen. Mitigación: cada retrospectiva revisa el backlog de ítems de seguridad y los tres líderes son corresponsables.
+- Si en fase 2 el proyecto crece, reevaluar si conviene reactivar el área de Seguridad con un líder nuevo.
+
+## Notas adicionales
+
+- Cualquier ADR que toque temas absorbidos debe enlazar a este ADR-0002 en su sección de Contexto para hacer explícita la genealogía de la decisión.

--- a/docs/adr/0003-estructura-equipo-devops.md
+++ b/docs/adr/0003-estructura-equipo-devops.md
@@ -1,0 +1,62 @@
+# ADR-0003: Estructura del equipo DevOps "Mediocampistas" y áreas
+
+- **Estado**: Aceptado
+- **Fecha**: 2026-04-26
+- **Área**: General
+- **Autores**: @edisoncast (Edison Castro, coordinador general)
+- **Aprobadores**: @steevensmelo (Steevens Castañeda, CI/CD), @Mateo454 (Mateo Marín, Infra), @lmichaelrc (Michael Rivera, SRE)
+
+## Contexto
+
+El proyecto Skorify se organiza simulando una estructura de industria con cuatro equipos: frontend, backend, devops y data. El equipo DevOps internamente se subdivide en áreas para cubrir el ciclo completo desde commit hasta operación, sin que una sola persona tenga que dominar todos los frentes.
+
+El equipo es heterogéneo: un coordinador general, tres sub-líderes con experiencia y la mayoría de integrantes son estudiantes. Sin una estructura clara:
+
+- Las decisiones se atascan en el coordinador general.
+- Los estudiantes no tienen un canal natural de mentoría técnica.
+- No hay claridad de a quién escalar un problema operativo.
+
+## Decisión
+
+El equipo DevOps "Mediocampistas" se organiza en **tres áreas** con un líder por área y aproximadamente 4 integrantes adicionales por área:
+
+| Área | Líder | Tamaño | Alcance |
+|------|-------|--------|---------|
+| **CI/CD** | Steevens Castañeda | 5 | GitHub Actions, pipelines, plantillas reusables, pre-commit, secret scanning, SCA, gestión de secretos en CI |
+| **Infra** | Mateo Marín | 5 | IaC (CDK frontend, SAM backend), recursos AWS, ambientes, IAM, OIDC, red, KMS, gestión de secretos runtime, cost governance |
+| **SRE** | Michael Rivera | 5 | Observabilidad (Datadog), logging estructurado, métricas, traces, alertas, audit logging (CloudTrail), runbooks, postmortems |
+
+**Coordinación general**: Edison Castro. Responsable de alinear las tres áreas, desbloquear dependencias inter-área y firmar como autor o revisor cruzado en ADRs generales.
+
+**Reglas de operación**:
+
+1. Cada área es dueña de su carpeta de ADRs (`docs/adr/{ci-cd,infra,sre}/`).
+2. Los ADRs generales viven en `docs/adr/` y son escritos típicamente por el coordinador general o por consenso de los tres líderes.
+3. Aprobación de ADRs específicos de área: 2 personas del área + 1 revisor de otra área.
+4. Aprobación de ADRs sensibles (IAM, OIDC, red, secretos, audit logs): los tres líderes de área (ver ADR-0002).
+5. Los estudiantes están explícitamente invitados a proponer y revisar ADRs como parte del proceso formativo.
+
+## Consecuencias
+
+### Positivas
+
+- Ownership claro por temática técnica.
+- Los estudiantes saben a quién acudir según el tema.
+- Las decisiones que afectan a una sola área no requieren consenso de todo el equipo.
+- La coordinación general no se vuelve cuello de botella en cada decisión.
+
+### Negativas / Trade-offs
+
+- Riesgo de silos: que CI/CD no entienda lo que hace Infra. Mitigación: cross-review obligatorio en ADRs.
+- Si un líder se ausenta, su área queda sin dirección. Mitigación: los líderes documentan sus decisiones en ADRs para que sean reproducibles.
+- Tamaño fijo de 5 por área es rígido; si el proyecto crece, habrá que reorganizar.
+
+### Neutrales / Riesgos a monitorear
+
+- La disolución del área de Seguridad (ver ADR-0002) cargó responsabilidades extra sobre las tres áreas. Monitorear si los líderes están sobrecargados.
+- Reevaluar la estructura al final del MVP. Si una persona se mueve de área, registrar el cambio.
+
+## Notas adicionales
+
+- El equipo se denomina "Mediocampistas". El origen del nombre lo conoce el grupo y no se documenta aquí.
+- Los handles individuales de GitHub y los equipos de la org `aws-ug-manizales` (referenciados en CODEOWNERS) están pendientes de definir/crear al momento de aceptar este ADR.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,54 @@
+# Architecture Decision Records (ADRs)
+
+Esta carpeta contiene todas las decisiones arquitectónicas del equipo DevOps "Mediocampistas".
+
+## Formato
+
+Usamos el formato **Nygard** ([plantilla](./0000-template.md)). Cada ADR tiene:
+
+- **Estado**: `Propuesto`, `Aceptado`, `Rechazado`, `Obsoleto` o `Reemplazado por ADR-XXXX`
+- **Contexto**, **Decisión** y **Consecuencias** como secciones obligatorias
+
+## Proceso
+
+1. Se propone un ADR vía Pull Request con estado `Propuesto`.
+2. Aprobación: **2 personas del área dueña + 1 cruzado** de otra área.
+3. ADRs sensibles (IAM, OIDC, red, secretos, audit logs) requieren los **tres líderes de área** (Steevens Castañeda, Mateo Marín, Michael Rivera).
+4. Una vez mergeado, el estado pasa a `Aceptado`.
+5. Cambios sobre un ADR aceptado → **ADR nuevo** que `Reemplaza por: ADR-XXXX`. No se editan ADRs aceptados.
+
+Ver [ADR-0001 — Adopción del formato y proceso de ADRs](./0001-adopcion-formato-adr.md).
+
+## Organización
+
+```
+docs/adr/
+├── 0000-template.md
+├── 0001-adopcion-formato-adr.md          # generales (transversales)
+├── 0002-...md
+├── ci-cd/                                # owner: Steevens Castañeda
+├── infra/                                # owner: Mateo Marín
+└── sre/                                  # owner: Michael Rivera
+```
+
+## Índice general
+
+### Generales (transversales)
+
+| ADR | Título | Estado |
+|-----|--------|--------|
+| [0001](./0001-adopcion-formato-adr.md) | Adopción del formato Nygard y proceso de ADRs | Aceptado |
+| [0002](./0002-redistribucion-responsabilidades-seguridad.md) | Redistribución de responsabilidades tras disolución del área de Seguridad | Aceptado |
+| [0003](./0003-estructura-equipo-devops.md) | Estructura del equipo DevOps (Mediocampistas) y áreas | Aceptado |
+
+### Por área
+
+- [CI/CD](./ci-cd/README.md)
+- [Infra](./infra/README.md)
+- [SRE](./sre/README.md)
+
+## Convenciones de numeración
+
+- Numeración por área (cada carpeta tiene su `0001`, `0002`, ...).
+- ADRs generales viven en la raíz de `docs/adr/` y comparten su propia secuencia.
+- Nombre de archivo: `NNNN-titulo-en-kebab-case.md`.

--- a/docs/adr/ci-cd/0001-github-actions-plataforma-cicd.md
+++ b/docs/adr/ci-cd/0001-github-actions-plataforma-cicd.md
@@ -1,0 +1,55 @@
+# ADR-CICD-0001: GitHub Actions como plataforma de CI/CD
+
+- **Estado**: Aceptado
+- **Fecha**: 2026-04-26
+- **Área**: CI/CD
+- **Autores**: @steevensmelo (Steevens Castañeda)
+- **Aprobadores**: @steevensmelo, @Mateo454, @lmichaelrc, @edisoncast
+
+## Contexto
+
+El proyecto Skorify necesita una plataforma de CI/CD que automatice validación de código, ejecución de pruebas, escaneo de seguridad y despliegue a tres ambientes (DEV, STG, PROD) sobre AWS. La plataforma será usada por cuatro equipos (frontend, backend, data y devops) con perfiles dispares: sub-líderes con experiencia y mayoría de estudiantes en su primer proyecto.
+
+Restricciones que orientaron la decisión:
+
+- Los repositorios del proyecto ya viven en GitHub bajo la org `aws-ug-manizales`.
+- Presupuesto limitado por ser un proyecto comunitario; no podemos pagar plataformas con licencias caras.
+- Curva de aprendizaje debe ser razonable para estudiantes; preferimos herramientas con documentación abundante en español/inglés y ejemplos públicos.
+- Necesitamos integraciones nativas con AWS (OIDC), análisis de seguridad y entornos protegidos para aprobaciones.
+
+Alternativas consideradas durante la discusión del equipo:
+
+- **GitHub Actions**: integrado al hosting del código, sin servidor adicional, marketplace amplio.
+- **AWS CodePipeline + CodeBuild**: nativo de AWS pero requiere más configuración y la curva inicial es más empinada.
+- **Jenkins / GitLab CI / CircleCI**: descartadas por requerir hosting adicional o por estar fuera del ecosistema en el que ya trabajamos.
+
+## Decisión
+
+Adoptamos **GitHub Actions** como plataforma única de CI/CD para todos los repositorios del proyecto Skorify (Skorify_Frontend, Skorify_Backend, Skorify_Data y Skorify_DevOps).
+
+Implicaciones inmediatas:
+
+1. Todos los pipelines se definen en archivos `.github/workflows/*.yml` o se invocan vía `workflow_call` desde plantillas centralizadas en `Skorify_DevOps`.
+2. Los ambientes de despliegue se modelan con **GitHub Environments** (DEV, STG, PROD) con sus propios secretos y reglas de protección.
+3. La autenticación a AWS se hace vía **OIDC** (sin credenciales de larga duración en GitHub Secrets) — ver ADR-INFRA-0005.
+4. Los runners son los hospedados por GitHub (`ubuntu-latest`); no se usan self-hosted runners en la fase MVP.
+
+## Consecuencias
+
+### Positivas
+
+- Cero infraestructura adicional para el equipo: la plataforma ya está disponible donde vive el código.
+- Marketplace de actions reduce el código boilerplate de los pipelines.
+- `workflow_call` permite centralizar plantillas y versionarlas — ver ADR-CICD-0004.
+- GitHub Environments + Required Reviewers cubre los requerimientos de aprobación a producción.
+
+### Negativas / Trade-offs
+
+- Vendor lock-in con GitHub: si en el futuro el código se mueve a otra plataforma, los workflows hay que reescribirlos.
+- Costos de minutos de runner pueden subir si crecen los pipelines (especialmente E2E y performance en fase 2). Se mitiga con caching, jobs concurrentes selectivos y filtros por path.
+- Los runners hospedados son menos flexibles que self-hosted (versiones de OS, herramientas no instaladas).
+
+### Neutrales / Riesgos a monitorear
+
+- Monitorear consumo de minutos por mes para detectar antes de alcanzar el límite del plan gratis del org.
+- Si en fase 2 se introducen pruebas de carga pesadas, evaluar si conviene un self-hosted runner para esos jobs específicos.

--- a/docs/adr/ci-cd/0002-branching-gitflow.md
+++ b/docs/adr/ci-cd/0002-branching-gitflow.md
@@ -1,0 +1,67 @@
+# ADR-CICD-0002: Estrategia de branching GitFlow
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: CI/CD
+- **Autores**: @steevensmelo
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+El proyecto despliega a tres ambientes (DEV, STG, PROD) y usa una sola cuenta AWS. Necesitamos una estrategia de branching que:
+
+- Sea entendible por estudiantes en su primer proyecto.
+- Soporte hotfixes urgentes sin saltarse las validaciones.
+- Esté alineada con el documento `Skorify_CICD_strategy.pdf` v1.0 (abril 2026), que ya describe el flujo `develop` → DEV, `release/*` → STG, `main` → PROD, `hotfix/*`.
+
+> **TODO** — completar por @steevensmelo:
+> - Justificar elección de GitFlow vs alternativas (trunk-based, GitHub Flow).
+> - Definir nomenclatura exacta de ramas (`feature/<jira-id>-...`, `release/v1.2.0`, `hotfix/...`).
+> - Reglas de protección por rama.
+
+<!--
+NOTA OBSERVADA (2026-04-26, al clonar los 3 repos):
+
+El estado actual de los repos no es consistente con `Skorify_CICD_strategy.pdf`,
+que define la rama de integración como `develop`. La realidad observada:
+
+| Repo                | Rama de integración | Otras ramas relevantes      |
+|---------------------|---------------------|-----------------------------|
+| Skorify_Frontend    | develop             | (coincide con la estrategia)|
+| Skorify_Backend     | development         | (NO coincide)               |
+| Skorify_Data        | development         | ya tiene `staging` activa   |
+
+Convenciones de nombres de feature branch que conviven hoy:
+  - `feat/...`
+  - `feature/...`
+  - `feature/H06/...` (con ID de historia)
+  - `feature/h04-...` (con ID en kebab)
+
+Los mensajes de commit existentes no siguen Conventional Commits de forma
+uniforme (`Configurar deploy`, `Agrega pipeline`, `feat: ...` mezclados).
+
+Decisiones a tomar al cerrar este ADR:
+  1) ¿Estandarizamos en `develop` (lo que dice el doc) o en `development` (mayoritario en los repos)?
+  2) Si cambiamos `development` → `develop` o viceversa, plan de migración por repo.
+  3) Convención única de nombres de feature branch.
+  4) Cómo tratar lo que ya hizo el equipo data (incluyendo su rama `staging`).
+-->
+
+
+## Decisión
+
+<!-- TODO: redactar por @steevensmelo -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->

--- a/docs/adr/ci-cd/0003-mapeo-rama-ambiente-triggers.md
+++ b/docs/adr/ci-cd/0003-mapeo-rama-ambiente-triggers.md
@@ -1,0 +1,42 @@
+# ADR-CICD-0003: Mapeo rama → ambiente y triggers de workflow
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: CI/CD
+- **Autores**: @steevensmelo
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+Definida la estrategia GitFlow (ADR-CICD-0002), hay que formalizar qué pipeline se dispara con cada evento de git y a qué ambiente despliega. El documento `Skorify_CICD_strategy.pdf` define el siguiente mapeo, que este ADR adopta y formaliza:
+
+| Trigger | Workflow | Despliegue |
+|---------|----------|------------|
+| `pull_request` a `develop`, `release/*`, `main` | `ci-pr-validation.yaml` | ninguno |
+| `push` a `develop` | `cd-dev-deploy.yaml` | DEV (auto) |
+| `push` a `release/*` | `cd-staging-deploy.yaml` | STG (auto, pruebas completas) |
+| `push` a `main` | `cd-prod-deploy.yaml` | PROD (con required reviewers) |
+| `push` a `hotfix/*` | `cd-hotfix-deploy.yaml` | flujo acelerado a PROD |
+
+> **TODO** — completar por @steevensmelo:
+> - Especificar tipos exactos de evento `pull_request` (opened, synchronize, reopened).
+> - Detallar cómo se manejan despliegues fallidos (¿bloquea el siguiente push?).
+> - Política de `concurrency:` para evitar despliegues concurrentes al mismo ambiente.
+
+## Decisión
+
+<!-- TODO: redactar por @steevensmelo -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->

--- a/docs/adr/ci-cd/0004-plantillas-reusable-workflows.md
+++ b/docs/adr/ci-cd/0004-plantillas-reusable-workflows.md
@@ -1,0 +1,65 @@
+# ADR-CICD-0004: Plantillas centralizadas vía reusable workflows
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: CI/CD
+- **Autores**: @steevensmelo
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+Tres repos de aplicación (Skorify_Frontend, Skorify_Backend, Skorify_Data) necesitan pipelines con stages comunes (lint, unit, SCA, build, deploy). Si cada repo mantiene su propia copia de los workflows:
+
+- Una corrección de seguridad o un cambio en la convención hay que aplicarlo manualmente en N repos.
+- La evolución natural lleva a divergencia: cada repo termina con su propia variante y nadie sabe cuál es la "buena".
+- Los estudiantes se pierden cuando ven tres formas diferentes de hacer lo mismo.
+
+GitHub Actions ofrece **reusable workflows** (`workflow_call`) que permiten que un repo central (Skorify_DevOps) publique workflows versionados y que los repos de aplicación los consuman con `uses: aws-ug-manizales/Skorify_DevOps/.github/workflows/<archivo>.yml@v1`.
+
+> **TODO** — completar por @steevensmelo:
+> - Diseñar inputs y secrets que cada workflow recibe.
+> - Definir cuándo usar reusable workflow vs composite action vs script.
+
+<!--
+DECISIÓN PARCIAL YA TOMADA por el líder de CI/CD (commit 15288b9, 2026-04-26):
+
+Granularidad: **un workflow por (stage, componente)**, con nombrado
+`stage-componente.yml`. Ejemplos creados:
+  - `lint-frontend.yml`, `lint-backend.yml`, `lint-data.yml`
+  - `unit-tests-frontend.yml`, `unit-tests-backend.yml`
+  - `build-frontend.yml`, `build-backend.yml`
+  - `deploy-frontend.yml`, `deploy-backend.yml`
+  - `sca-generic.yml` (cross-componente)
+
+Esto da granularidad fina: cada repo de aplicación arma su pipeline
+combinando solo los stages que necesita, en lugar de invocar un
+megaworkflow por flujo. Encaja con el modelo de stages descrito en
+`Skorify_CICD_strategy.pdf`.
+
+Composite actions (en `actions/` raíz, no `.github/actions/`) se usan para
+pasos atómicos compartidos entre workflows: `setup-node`, `setup-aws-credentials`,
+`run-trivy`, `run-eslint`, `notify-slack`, `create-release-tag`.
+
+Versionado: ver ADR-CICD-0009.
+
+Documentación de uso: `docs/contributing.md` (mantenida por el líder CI/CD).
+-->
+
+## Decisión
+
+<!-- TODO: redactar formalmente por @steevensmelo, incorporando la decisión
+ya tomada arriba (modelo stage-componente) -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->

--- a/docs/adr/ci-cd/0005-stages-mvp-lint-unit-sca.md
+++ b/docs/adr/ci-cd/0005-stages-mvp-lint-unit-sca.md
@@ -1,0 +1,59 @@
+# ADR-CICD-0005: Stages obligatorios MVP — Lint, Unit, SCA
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: CI/CD
+- **Autores**: @steevensmelo
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+El documento `Skorify_CICD_strategy.pdf` define una lista completa de stages aspirantes (lint, unit, SCA, SAST, build, integration, E2E, performance, deploy, notificación). Implementarlos todos en la primera iteración no es realista para el timeline ni para el perfil del equipo.
+
+El equipo CI/CD definió que el alcance MVP cubrirá solo **Linting & formatting**, **Unit tests** y **SCA**. SAST, integration, E2E y performance quedan para fase 2.
+
+Razones para la priorización:
+
+- Lint y unit cubren la mayor parte de defectos comunes con bajo costo de implementación.
+- SCA (con Trivy o equivalente) detecta vulnerabilidades en dependencias, una superficie de ataque que crece sola sin ningún cambio de código.
+- SAST y E2E requieren más curva (tuning de reglas Semgrep, escritura de pruebas Playwright) y se introducen cuando el equipo gane fluidez.
+
+> **TODO** — completar por @steevensmelo:
+> - Elegir herramientas concretas por tipo de repo (los tres son Node + TypeScript: eslint+prettier aplica a FE, BE y Data).
+> - Elegir framework de unit testing (Vitest, Jest, etc.) por consistencia con cada equipo de aplicación.
+> - Elegir herramienta SCA y umbral de severidad que rompe el pipeline.
+> - Definir cuándo se evolucionará a fase 2 (criterios de readiness).
+
+## Decisión
+
+<!-- TODO: redactar por @steevensmelo -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->
+
+<!--
+NOTA OBSERVADA (auditoría 2026-04-26):
+
+Estado real al momento de redactar:
+- Skorify_Frontend: tiene ESLint + Prettier configurados; sin tests escritos; sin SCA.
+- Skorify_Backend: sin ESLint configurado; tiene Jest configurado pero sin tests; sin SCA.
+- Skorify_Data: sin ESLint, sin Jest/Vitest, sin SCA; 37 PRs mergeados sin checks automáticos.
+
+Implementar los stages MVP es trabajo greenfield para BE y Data, y completar
+unit tests + SCA para los tres repos. Plan de adopción incremental:
+1) Habilitar lint en BE y Data (instalar ESLint + Prettier).
+2) Activar Trivy como job SCA en los tres repos.
+3) Escribir primeros unit tests cuando cada equipo pueda priorizar.
+-->
+

--- a/docs/adr/ci-cd/0006-conventional-commits.md
+++ b/docs/adr/ci-cd/0006-conventional-commits.md
@@ -1,0 +1,42 @@
+# ADR-CICD-0006: Conventional Commits + commitlint
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: CI/CD
+- **Autores**: @steevensmelo
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+El proyecto involucra varios equipos y mayoría de estudiantes. Los mensajes de commit varían en estilo, lo cual dificulta:
+
+- Generar changelogs automáticos.
+- Decidir el siguiente número de versión (semver) sin intervención manual.
+- Filtrar commits relevantes en la historia (`fix:` vs `feat:` vs `docs:`).
+
+**Conventional Commits** es un estándar simple (`<tipo>(<alcance>): <descripción>`) ampliamente adoptado. **commitlint** valida los mensajes en un hook de pre-commit y/o como check de CI.
+
+Tipos a habilitar (propuestos): `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`, `perf`, `revert`, `adr`.
+
+> **TODO** — completar por @steevensmelo:
+> - Decidir si se aplica solo en PRs (validación del título) o también en cada commit.
+> - Decidir si se integra `semantic-release` para automatizar tags y changelog (genera versiones desde mensajes), o si las versiones son manuales.
+> - Definir convención exacta de `<alcance>` (¿nombre del módulo, área, ticket?).
+
+## Decisión
+
+<!-- TODO: redactar por @steevensmelo -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->

--- a/docs/adr/ci-cd/0007-pre-commit-hooks.md
+++ b/docs/adr/ci-cd/0007-pre-commit-hooks.md
@@ -1,0 +1,66 @@
+# ADR-CICD-0007: Pre-commit hooks por tipo de proyecto
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: CI/CD
+- **Autores**: @steevensmelo
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+Detectar problemas en el commit local es más barato que detectarlos en CI, y mucho más barato que detectarlos en un revisor humano. La herramienta `pre-commit` (https://pre-commit.com) gestiona hooks declarativos en un archivo `.pre-commit-config.yaml`.
+
+Hooks comunes propuestos para los tres repos de aplicación (frontend, backend, data):
+
+- **gitleaks** — secret scanning (responsabilidad absorbida de Seguridad, ver ADR-0002 general).
+- **commitlint** — validación de Conventional Commits (ver ADR-CICD-0006).
+- **trailing-whitespace**, **end-of-file-fixer** — higiene básica.
+
+Hooks específicos por tipo de repo:
+
+- **Frontend (Skorify_Frontend)**: `eslint`, `prettier`, `tsc --noEmit`.
+- **Backend (Skorify_Backend)**: `eslint`, `prettier`, `tsc --noEmit`. Si se editan plantillas SAM, considerar `cfn-lint` o equivalente.
+- **Data (Skorify_Data)**: Node.js + TypeScript + pnpm (confirmado por auditoría 2026-04-26). Aplican los mismos hooks que Backend: `eslint`, `prettier`, `tsc --noEmit`. Sin SAM ni CFN.
+
+Las configuraciones de referencia viven en `pre-commit/` de este repo y los repos de aplicación las extienden o copian.
+
+> **TODO** — completar por @steevensmelo:
+> - Elegir el conjunto definitivo de hooks por tipo de repo.
+> - Decidir si los hooks son obligatorios (instalación documentada) o un job de CI los ejecuta también como red de seguridad.
+> - Definir quién mantiene los archivos de referencia en `pre-commit/`.
+
+## Decisión
+
+<!-- TODO: redactar por @steevensmelo -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->
+
+<!--
+NOTA OBSERVADA (auditoría 2026-04-26):
+
+Estado real al momento de redactar:
+- Skorify_Frontend: ya usa Husky + lint-staged. Hook `.husky/pre-commit` ejecuta
+  `npx lint-staged`, con reglas declaradas en `package.json`.
+- Skorify_Backend: sin pre-commit hooks de ningún tipo.
+- Skorify_Data: sin pre-commit hooks.
+
+El cascarón actual de este ADR asume el framework `pre-commit`
+(https://pre-commit.com), que NO es lo que FE usa. Existe entonces una decisión
+cruzada pendiente: ¿estandarizar en Husky (lo de FE) o en `pre-commit` framework?
+Ver ADR-CICD-0010.
+
+Mientras se decide, los repos BE y Data NO están adoptando ningún hook todavía.
+-->
+

--- a/docs/adr/ci-cd/0008-estrategia-hotfix-rollback.md
+++ b/docs/adr/ci-cd/0008-estrategia-hotfix-rollback.md
@@ -1,0 +1,37 @@
+# ADR-CICD-0008: Estrategia de hotfix y rollback
+
+- **Estado**: Propuesto (fase 2)
+- **Fecha**: 2026-04-26
+- **Área**: CI/CD
+- **Autores**: @steevensmelo
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+`Skorify_CICD_strategy.pdf` describe un pipeline `cd-hotfix-deploy.yaml` para correcciones urgentes desde ramas `hotfix/*` con un flujo acelerado (lint + unit + build, sin pruebas pesadas) y luego merge dual a `main` y `develop`. Falta formalizar:
+
+- Criterios para declarar un cambio como hotfix (vs un fix normal).
+- Rollback: ¿se hace por CloudFront cache invalidation + S3 versioning para frontend? ¿Por Lambda alias para backend? ¿Por re-deploy de la versión anterior con un workflow `manual_dispatch`?
+- Quién aprueba un hotfix a producción (¿requiere los mismos 2 reviewers que un release normal o puede ser un solo líder en horario de incidente?).
+
+Este ADR queda en estado **Propuesto** hasta que el equipo tenga MVP de pipelines normales funcionando y haya un primer incidente o ejercicio que motive la decisión.
+
+> **TODO** — completar por @steevensmelo cuando los pipelines DEV/STG/PROD estén estables.
+
+## Decisión
+
+<!-- TODO -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->

--- a/docs/adr/ci-cd/0009-versionado-semver-plantillas.md
+++ b/docs/adr/ci-cd/0009-versionado-semver-plantillas.md
@@ -1,0 +1,39 @@
+# ADR-CICD-0009: Versionado semver de plantillas centralizadas
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: CI/CD
+- **Autores**: @steevensmelo
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+Los repos de aplicación consumirán los reusable workflows publicados en Skorify_DevOps (ver ADR-CICD-0004). Si los repos referencian las plantillas con `@main`, cualquier cambio en el repo central se aplica inmediatamente y puede romper builds sin aviso. Si las referencian con SHA, los repos quedan congelados en una versión opaca.
+
+Un esquema **semver con tags** balancea ambos extremos:
+
+- `v1`, `v2`, ... — tags móviles que apuntan al último release menor de esa mayor. Permiten recibir parches sin acción manual.
+- `v1.0.0`, `v1.1.0`, `v1.1.1` — tags inmutables para fijar a una versión exacta cuando se necesita reproducibilidad estricta.
+
+> **TODO** — completar por @steevensmelo:
+> - Definir reglas para mayor/menor/parche en este contexto (¿qué cuenta como breaking change en un workflow?).
+> - Decidir si se usan release notes en GitHub Releases para cada bump y qué formato.
+> - Decidir si se automatiza el bump con `semantic-release` (depende de ADR-CICD-0006) o se hace manual.
+
+## Decisión
+
+<!-- TODO: redactar por @steevensmelo -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->

--- a/docs/adr/ci-cd/0010-husky-vs-pre-commit-framework.md
+++ b/docs/adr/ci-cd/0010-husky-vs-pre-commit-framework.md
@@ -1,0 +1,64 @@
+# ADR-CICD-0010: Estandarización de pre-commit — Husky vs framework `pre-commit`
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: CI/CD
+- **Autores**: @steevensmelo (Steevens Castañeda)
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+ADR-CICD-0007 estableció el uso de pre-commit hooks por tipo de proyecto, asumiendo el framework `pre-commit` (https://pre-commit.com) — el cascarón actual en `pre-commit/*.pre-commit-config.yaml` está orientado a esa herramienta. La auditoría del 2026-04-26 reveló que **`Skorify_Frontend` ya usa Husky + lint-staged**, no `pre-commit` framework:
+
+- `.husky/pre-commit` ejecuta `npx lint-staged`.
+- Reglas declaradas en `package.json` bajo `lint-staged`.
+- ESLint + Prettier corren contra los archivos staged.
+
+Los repos `Skorify_Backend` y `Skorify_Data` no tienen hooks de ningún tipo todavía.
+
+Hay una decisión cruzada que tomar antes de pedir a BE y Data que adopten algo:
+
+**Opción A — Estandarizar en Husky + lint-staged**:
+- Pros: FE ya lo usa; ambas son tools del ecosistema npm/Node, compatibles con los 3 repos (todos son Node).
+- Pros: instalación trivial (`npm install --save-dev husky lint-staged`).
+- Contras: específico de proyectos JavaScript/TypeScript; si Data o cualquier futuro repo del proyecto añade Python u otro stack, Husky no sirve directamente.
+
+**Opción B — Estandarizar en framework `pre-commit`**:
+- Pros: agnóstico de lenguaje; soporta hooks Python, Go, Ruby, JS, etc.
+- Pros: gestión centralizada de versiones de los hooks vía `.pre-commit-config.yaml`.
+- Contras: requiere instalar Python en la máquina del desarrollador (la herramienta es Python).
+- Contras: el equipo FE tendría que migrar de Husky, perdiendo el setup que ya funciona.
+
+**Opción C — Híbrido (NO recomendado)**:
+- Cada repo elige; FE sigue con Husky, BE/Data adoptan `pre-commit`.
+- Contras: tres flavors distintos de hooks complican onboarding y la guía única de desarrollo.
+
+> **TODO** — completar por @steevensmelo:
+> - Decidir entre A y B.
+> - Si se elige A (Husky), reemplazar los archivos `pre-commit/*.pre-commit-config.yaml` por configs de `lint-staged` y un script de `husky/install.sh`.
+> - Si se elige B (`pre-commit`), pedir al equipo FE migrar de Husky.
+> - Especificar el conjunto exacto de hooks por tipo de repo.
+> - Definir si el hook se enforce solo localmente o también como job de CI (defensa en profundidad).
+
+## Decisión
+
+<!-- TODO -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->
+
+## Notas adicionales
+
+- ADR relacionado: ADR-CICD-0007 (pre-commit hooks por tipo de proyecto). Este ADR es una decisión cruzada que afina la herramienta concreta.
+- Cuando se cierre este ADR, los archivos de cascarón en `pre-commit/` se reemplazarán por la configuración correspondiente (Husky o `pre-commit` framework).

--- a/docs/adr/ci-cd/README.md
+++ b/docs/adr/ci-cd/README.md
@@ -1,0 +1,24 @@
+# ADRs — Área CI/CD
+
+**Líder de área**: Steevens Castañeda
+
+**Alcance**: GitHub Actions, pipelines, plantillas reusables, pre-commit, secret scanning, SCA, gestión de secretos en CI.
+
+## Índice
+
+| ADR | Título | Estado |
+|-----|--------|--------|
+| [0001](./0001-github-actions-plataforma-cicd.md) | GitHub Actions como plataforma de CI/CD | Aceptado |
+| [0002](./0002-branching-gitflow.md) | Estrategia de branching GitFlow | Aceptado |
+| [0003](./0003-mapeo-rama-ambiente-triggers.md) | Mapeo rama → ambiente y triggers de workflow | Aceptado |
+| [0004](./0004-plantillas-reusable-workflows.md) | Plantillas centralizadas vía reusable workflows | Aceptado |
+| [0005](./0005-stages-mvp-lint-unit-sca.md) | Stages obligatorios MVP: Lint, Unit, SCA | Aceptado |
+| [0006](./0006-conventional-commits.md) | Conventional Commits + commitlint | Propuesto |
+| [0007](./0007-pre-commit-hooks.md) | Pre-commit hooks por tipo de proyecto | Aceptado |
+| [0008](./0008-estrategia-hotfix-rollback.md) | Estrategia de hotfix y rollback | Propuesto (fase 2) |
+| [0009](./0009-versionado-semver-plantillas.md) | Versionado semver de plantillas centralizadas | Aceptado |
+| [0010](./0010-husky-vs-pre-commit-framework.md) | Estandarización de pre-commit — Husky vs framework `pre-commit` | Propuesto |
+
+## Documento de referencia
+
+La estrategia general de CI/CD está descrita en `Skorify_CICD_strategy.pdf` (versión 1.0, abril 2026). Los ADRs de esta área formalizan y extienden ese documento.

--- a/docs/adr/infra/0001-cdk-frontend-sam-backend.md
+++ b/docs/adr/infra/0001-cdk-frontend-sam-backend.md
@@ -1,0 +1,65 @@
+# ADR-INFRA-0001: CDK para frontend y SAM para backend
+
+- **Estado**: Aceptado
+- **Fecha**: 2026-04-26
+- **Área**: Infra
+- **Autores**: @Mateo454 (Mateo Marín)
+- **Aprobadores**: @Mateo454, @steevensmelo, @lmichaelrc, @edisoncast
+
+## Contexto
+
+El proyecto necesita Infrastructure as Code (IaC) para los recursos AWS de los tres ambientes. El equipo evaluó las opciones disponibles dentro del ecosistema AWS y de la comunidad:
+
+- **AWS CDK** (Cloud Development Kit) — define infraestructura en lenguajes de programación generales (TypeScript, Python, etc.) y compila a CloudFormation. Tiene constructs de alto nivel para casi todos los servicios AWS.
+- **AWS SAM** (Serverless Application Model) — extensión de CloudFormation optimizada para aplicaciones serverless (Lambda, API Gateway, DynamoDB). Sintaxis YAML simplificada y CLI con utilidades específicas (local invoke, deploy, build).
+- **Terraform** — multi-cloud, lenguaje propio (HCL), ecosistema maduro.
+- **CloudFormation puro** — más verboso, sin abstracciones de alto nivel.
+
+El equipo decidió usar **dos herramientas distintas**:
+
+- **CDK para frontend** porque el stack del frontend (S3 + CloudFront + Route53 + ACM) tiene varias piezas no-serverless donde los constructs de alto nivel de CDK reducen mucho boilerplate.
+- **SAM para backend** porque el backend es 100% serverless (Lambda + API Gateway) y SAM tiene utilidades específicas para iterar localmente (`sam local invoke`, `sam local start-api`).
+
+Esta decisión se tomó antes de iniciar el proyecto y se documenta aquí en lugar de re-evaluarse. La decisión está aceptada; este ADR registra contexto y consecuencias para mantenedores futuros.
+
+## Decisión
+
+1. La infraestructura del frontend (Skorify_Frontend y sus recursos AWS) se define con **AWS CDK** en TypeScript, ubicado en una carpeta `infra/` dentro del repo Skorify_Frontend.
+2. La infraestructura del backend (Skorify_Backend y sus recursos AWS) se define con **AWS SAM** en YAML, ubicada junto al código de las funciones Lambda en Skorify_Backend.
+3. La infraestructura específica del repo Skorify_Data (motor AWS para PostgreSQL: RDS vs Aurora vs Aurora Serverless v2) se decidirá en un ADR aparte. El stack del repo Data ya está definido (Node.js + TypeScript + librería con TypeORM + Knex; ver ADR-INFRA-0008 y ADR-INFRA-0010).
+4. Los recursos compartidos entre ambientes (cuenta AWS, OIDC provider para GitHub, IAM roles transversales) se definen con **CDK** en un repo o carpeta a definir por el equipo Infra.
+
+## Consecuencias
+
+### Positivas
+
+- Cada equipo de aplicación usa la herramienta que mejor se ajusta a su carga de trabajo: el equipo backend itera localmente con `sam local`; el equipo frontend aprovecha los constructs de CDK para CDN, certificados y DNS.
+- Los repos de aplicación quedan auto-contenidos: cada uno declara su propia infra junto a su código.
+
+### Negativas / Trade-offs
+
+- **Dos herramientas que aprender** para los estudiantes que roten entre frontend y backend. Mitigación: documentar ejemplos básicos en `docs/onboarding/` y ofrecer parejas mixtas durante el bootstrap.
+- **Mantenimiento dual**: bumps de versión, configuración de credenciales y patrones de despliegue se duplican.
+- Los recursos cross-stack (un bucket de logs central, un secret compartido) requieren coordinación porque viven en el repo de uno de los dos equipos o en un tercer repo.
+- CloudFormation drift puede ocurrir si una herramienta toca recursos de la otra; hay que evitarlo con disciplina de scoping.
+
+### Neutrales / Riesgos a monitorear
+
+- Si el equipo en algún momento prefiere unificar (por ejemplo, todo a CDK o todo a Terraform), este ADR deberá ser reemplazado por uno nuevo.
+- Monitorear el costo de switching cuando alguien rota entre frontend y backend; si se vuelve fricción real, replantear.
+
+<!--
+NOTA OBSERVADA (auditoría 2026-04-26):
+
+Al momento de la auditoría, la infra AWS aún no ha sido construida por el equipo Infra.
+Hallazgos por repo:
+- Skorify_Frontend: no existe carpeta `infra/` con código CDK.
+- Skorify_Backend: no existe `template.yaml` SAM en raíz; la plantilla solo aparece como
+  generador de código en `builders/src/single-lambda-aws/templates/sam.template.yaml`.
+- Skorify_Data: no aplica (no es responsable de infra de cómputo).
+
+Esta brecha entre el target descrito en este ADR y el estado real está documentada
+en ADR-INFRA-0009 (estado fase 0 y plan de migración a AWS). El target de este
+ADR sigue siendo válido y es el destino acordado del proyecto.
+-->
+

--- a/docs/adr/infra/0002-aislamiento-ambientes-cuenta-unica.md
+++ b/docs/adr/infra/0002-aislamiento-ambientes-cuenta-unica.md
@@ -1,0 +1,44 @@
+# ADR-INFRA-0002: Una cuenta AWS con aislamiento por prefijos + IAM + tags
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: Infra
+- **Autores**: @Mateo454
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+El proyecto opera con **una sola cuenta AWS** para los tres ambientes (DEV, STG, PROD). Esto es una restricción del proyecto comunitario (presupuesto, complejidad de gestionar Organizations) y no se revisará en el MVP.
+
+Operar tres ambientes en una cuenta tiene riesgos conocidos:
+
+- Blast radius compartido: un error en DEV puede tocar recursos de PROD si los IAM no están bien acotados.
+- Límites de servicio compartidos: los tres ambientes consumen las mismas cuotas (Lambda concurrency, API Gateway throttling).
+- Visibilidad de costos: hay que disciplinar tagging para distinguir consumo por ambiente.
+
+El equipo Infra debe definir las prácticas que mitiguen estos riesgos.
+
+> **TODO** — completar por @Mateo454:
+> - Convención de prefijos (`skorify-{env}-{servicio}`) y casing (kebab-case vs PascalCase) para nombres de recursos.
+> - IAM roles separados por ambiente con políticas que restrinjan el acceso a recursos del propio ambiente (condiciones por tag, ARN o prefijo).
+> - Tags obligatorios (`Environment`, `Project`, `Owner`, `CostCenter`).
+> - VPCs y subnets separadas o compartidas (decidir según necesidad real).
+> - Estrategia de límites/budgets por ambiente para evitar que DEV consuma cuota de PROD.
+
+## Decisión
+
+<!-- TODO -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->

--- a/docs/adr/infra/0003-frontend-nextjs-ssg-s3-cloudfront.md
+++ b/docs/adr/infra/0003-frontend-nextjs-ssg-s3-cloudfront.md
@@ -1,0 +1,61 @@
+# ADR-INFRA-0003: Frontend Next.js SSG en S3 + CloudFront
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: Infra
+- **Autores**: @Mateo454
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+El equipo frontend confirmó que Next.js se usará en modo **static export (SSG)**: `next build` genera HTML/CSS/JS estáticos sin requerir runtime servidor. Este modo permite servir el sitio desde un bucket S3 con CDN, sin necesidad de Lambda@Edge ni AWS Amplify Hosting ni OpenNext.
+
+Componentes propuestos:
+
+- **S3** — bucket privado con los artefactos estáticos.
+- **CloudFront** — distribución CDN con OAC (Origin Access Control) hacia S3.
+- **Route53** — zona DNS y registros para los hostnames de cada ambiente.
+- **ACM** — certificado TLS para CloudFront (debe estar en `us-east-1`).
+
+> **TODO** — completar por @Mateo454:
+> - Definir hostnames por ambiente (`dev.skorify.example`, `stg...`, `skorify.example`).
+> - Política de cache de CloudFront: TTL para HTML vs assets con hash.
+> - Estrategia de invalidación al desplegar (¿invalidación amplia o solo de páginas modificadas?).
+> - Headers de seguridad (CSP, HSTS, etc.) vía CloudFront Functions o Response Headers Policy.
+> - Estrategia de error pages 403/404 → `index.html` para SPA-routing si aplica.
+
+## Decisión
+
+<!-- TODO -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->
+
+<!--
+NOTA OBSERVADA (auditoría 2026-04-26):
+
+`Skorify_Frontend/next.config.ts` no incluye `output: 'export'`, por lo que Next.js
+no está en modo static export. Sin esa configuración, Next.js requiere runtime para
+SSR/API routes y no podría servirse desde S3+CloudFront puro como describe este ADR.
+
+Acción requerida antes de desplegar a la infra que construya el equipo Infra:
+- Equipo Frontend debe activar `output: 'export'` en `next.config.ts` y verificar
+  que ningún feature del repo dependa de SSR, API routes, ISR o middleware dinámico.
+- Si alguno de esos features es necesario, este ADR debe ser reemplazado por uno
+  con un target distinto (ej. SSR con OpenNext sobre Lambda+CloudFront).
+
+Restricción del proyecto: AWS Amplify Hosting queda fuera de alcance — el target
+acordado es S3 + CloudFront vía CDK. Ver ADR-INFRA-0009 para el plan de fase 0.
+-->
+

--- a/docs/adr/infra/0004-backend-lambda-apigw-typescript.md
+++ b/docs/adr/infra/0004-backend-lambda-apigw-typescript.md
@@ -1,0 +1,63 @@
+# ADR-INFRA-0004: Backend en Lambda + API Gateway + Node.js TypeScript
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: Infra
+- **Autores**: @Mateo454
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+El backend del proyecto Skorify es serverless: AWS Lambda como compute y API Gateway como entrada HTTP. El equipo backend confirmó que las funciones se escriben en **TypeScript** sobre runtime Node.js. SAM gestiona el packaging y despliegue (ver ADR-INFRA-0001).
+
+> **TODO** — completar por @Mateo454:
+> - Versión de runtime Node.js a fijar (la más reciente LTS soportada por Lambda al momento del MVP).
+> - Tipo de API Gateway: **REST API** vs **HTTP API**. HTTP API es más barato y suficiente para la mayoría de casos.
+> - Mecanismo de autenticación de las APIs (Cognito, JWT custom, API Keys, IAM, ninguno para MVP).
+> - Tamaño de memoria por defecto y timeout de las Lambdas.
+> - Cómo se construye el bundle TS: esbuild via `sam build`, manual, o capa Lambda compartida.
+> - Almacenamiento (DynamoDB? RDS Postgres compartido con data?).
+
+## Decisión
+
+<!-- TODO -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->
+
+<!--
+NOTA OBSERVADA (auditoría 2026-04-26):
+
+Al momento de la auditoría, Skorify_Backend NO corre en Lambda. Hallazgos:
+- El servidor arranca en puerto 9898 con `nodemon` (estilo monolito Node).
+- Usa el framework `@scifamek-open-source/iraca/web-api` (Iraca) para HTTP
+  routing y DI, no API Gateway nativo de AWS.
+- `template.yaml` SAM existe solo como GENERADOR de código en
+  `builders/src/single-lambda-aws/templates/sam.template.yaml`, no como
+  infraestructura desplegable.
+- `.github/workflows/deploy.yml` solo construye, no despliega a AWS.
+- No hay integración con Datadog, ni storage AWS conectado (DynamoDB/RDS).
+
+Restricción del proyecto: el backend DEBE correr en Lambda — es un acuerdo
+global confirmado por el coordinador. Este ADR sigue siendo el target válido.
+
+Acciones requeridas (a planificar entre BE + Infra):
+- Decidir si el código actual con Iraca se empaqueta como handler Lambda
+  (vía Lambda Web Adapter o adaptador HTTP) o si se reescribe a handlers nativos.
+- Construir el stack SAM real para Lambda + API Gateway por parte de Infra.
+- Migrar el workflow `deploy.yml` existente a un pipeline que sí despliegue.
+
+Plan de migración detallado en ADR-INFRA-0009.
+-->
+

--- a/docs/adr/infra/0005-oidc-github-aws.md
+++ b/docs/adr/infra/0005-oidc-github-aws.md
@@ -1,0 +1,43 @@
+# ADR-INFRA-0005: Autenticación GitHub Actions → AWS vía OIDC
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: Infra
+- **Autores**: @Mateo454
+- **Aprobadores**: <pendiente> (requiere los 3 líderes — toca IAM)
+
+## Contexto
+
+Los workflows de GitHub Actions necesitan credenciales para desplegar a AWS. Las dos opciones principales son:
+
+- **AWS access keys de larga duración almacenadas en GitHub Secrets**: simple de configurar pero presenta riesgo si las llaves se filtran (rotación manual, sin scope por repo/ramo).
+- **OIDC (OpenID Connect) entre GitHub y AWS**: GitHub emite un token de identidad por job; AWS lo intercambia por credenciales temporales asumiendo un IAM role con trust policy restringida a `repo:org/repo:ref:refs/heads/...`.
+
+OIDC elimina credenciales de larga duración, permite scoping fino (rol distinto por ambiente, restringido a ramas específicas) y es el estándar recomendado por AWS y GitHub para CI/CD.
+
+Esta es una decisión que toca IAM directamente, por lo cual requiere aprobación de los **tres líderes** según ADR-0002 general.
+
+> **TODO** — completar por @Mateo454:
+> - Definir nombre y ARN de los IAM roles por ambiente (`skorify-deploy-dev`, `skorify-deploy-stg`, `skorify-deploy-prd`).
+> - Trust policy: condiciones exactas (`token.actions.githubusercontent.com:sub` matching repo y ref).
+> - Permisos de cada rol: principio de menor privilegio (¿qué puede tocar cada rol en su ambiente?).
+> - Definir si un solo provider OIDC sirve a todos los repos o si se separa por repo.
+> - Documentar el procedimiento de bootstrap (crear el OIDC provider, los roles).
+
+## Decisión
+
+<!-- TODO -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->

--- a/docs/adr/infra/0006-tagging-naming-aws.md
+++ b/docs/adr/infra/0006-tagging-naming-aws.md
@@ -1,0 +1,47 @@
+# ADR-INFRA-0006: Estándar de tagging y naming AWS
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: Infra
+- **Autores**: @Mateo454
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+Tres ambientes en una sola cuenta AWS (ver ADR-INFRA-0002) hacen indispensable un estándar de tagging y naming para distinguir recursos por ambiente, atribuir costos y aplicar políticas IAM con condiciones por tag.
+
+Sin estándar, los recursos se mezclan, los reportes de Cost Explorer son inutilizables y los IAM roles no pueden restringirse correctamente.
+
+Tags candidatas (a definir por el equipo):
+
+- `Environment`: `dev` | `stg` | `prd`
+- `Project`: `skorify`
+- `Owner`: nombre del área o del líder responsable
+- `CostCenter`: para atribución de costos
+- `ManagedBy`: `cdk` | `sam` | `manual`
+
+Naming candidato: `skorify-{env}-{servicio}-{detalle}` en kebab-case.
+
+> **TODO** — completar por @Mateo454:
+> - Lista final de tags obligatorios y opcionales.
+> - Convención exacta de naming por tipo de recurso (algunos servicios AWS limitan caracteres o longitud).
+> - Cómo se enforce: ¿constructs CDK que añaden tags por defecto? ¿AWS Tag Policies? ¿linter de IaC?
+> - Política de revisión cuando un recurso se crea sin los tags requeridos.
+
+## Decisión
+
+<!-- TODO -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->

--- a/docs/adr/infra/0007-gestion-secretos.md
+++ b/docs/adr/infra/0007-gestion-secretos.md
@@ -1,0 +1,47 @@
+# ADR-INFRA-0007: Gestión de secretos — runtime y CI
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: Infra
+- **Autores**: @Mateo454
+- **Aprobadores**: <pendiente> (requiere los 3 líderes — toca secretos)
+
+## Contexto
+
+El proyecto manejará credenciales de Datadog, posibles API keys de servicios externos, secretos de base de datos (cuando data defina), y otros valores sensibles que **no** deben vivir en el código.
+
+Hay dos planos distintos donde se necesitan secretos:
+
+1. **Runtime AWS** (Lambdas, Tasks, etc.): para conectar a base de datos, llamar APIs externas, autenticar con servicios.
+2. **CI/CD GitHub Actions**: para autenticarse a Datadog, Slack, NPM registries, etc. (las credenciales AWS se resuelven vía OIDC, ver ADR-INFRA-0005).
+
+Opciones:
+
+- **AWS Secrets Manager**: secretos cifrados con KMS, rotación automática para algunos servicios, pricing por secreto.
+- **AWS Systems Manager Parameter Store**: parámetros (incluyendo `SecureString` cifrados con KMS), gratis hasta cierto volumen, sin rotación nativa.
+- **GitHub Environments secrets**: secretos por ambiente con required reviewers para acceso, ideal para CI.
+
+> **TODO** — completar por @Mateo454 (con revisión de @lmichaelrc para rotación):
+> - Decidir cuándo se usa Secrets Manager (rotación, cross-account) vs Parameter Store (simple, barato).
+> - Política de rotación: qué se rota automáticamente y qué requiere intervención manual.
+> - Cómo accede una Lambda a un secreto: ¿variable de entorno cifrada? ¿llamada SDK al inicio? ¿Lambda Powertools/extensión Secrets?
+> - Convención de naming de los secretos (paralelo al ADR-INFRA-0006).
+> - Política para los secretos de CI: cuáles van como GitHub Org secrets, cuáles por GitHub Environment.
+
+## Decisión
+
+<!-- TODO -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->

--- a/docs/adr/infra/0008-motor-postgresql.md
+++ b/docs/adr/infra/0008-motor-postgresql.md
@@ -1,0 +1,66 @@
+# ADR-INFRA-0008: Stack PostgreSQL — TypeORM (entidades) + Knex (migrations y queries)
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: Infra
+- **Autores**: equipo Data (decisión ya implementada en `Skorify_Data`)
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+El proyecto necesita una base de datos relacional. Tras conversación inicial entre los líderes, se confirmó **PostgreSQL** como motor. Este ADR fue marcado originalmente como "bloqueado" porque faltaba que el equipo data definiera el caso de uso y el stack concreto.
+
+La auditoría del 2026-04-26 sobre el repo `Skorify_Data` reveló que el equipo data ya implementó las decisiones técnicas y las tiene en código. Este ADR formaliza esa realidad para que sea revisable y aprobable, en lugar de quedar como conocimiento implícito en el repo.
+
+Hechos observados en `Skorify_Data` que motivan la decisión:
+
+- `package.json` declara `pg`, `typeorm`, `knex`.
+- `knexfile.js` configura el directorio `./migrations` con cliente `pg`.
+- `/entities` contiene 15 entidades TypeScript decoradas con `@Entity`, `@Column`, `@PrimaryGeneratedColumn`, etc. (TypeORM).
+- `/migrations` contiene un archivo Knex (`20260408210039_initial_setup.js`) que crea todas las tablas iniciales.
+- `lib/services/*.service.ts` extiende `BaseDataService` y usa Knex (no QueryBuilder de TypeORM) para ejecutar queries.
+- `docker-compose.yml` levanta `postgres:18.3-alpine` para desarrollo local.
+
+El equipo data eligió un **patrón híbrido inusual**: TypeORM solo para definir el schema vía decoradores y Knex para ejecutar migrations y queries. Es atípico y merece justificación explícita.
+
+Lo que **NO** está decidido aún:
+
+- El motor AWS exacto (RDS Postgres vs Aurora vs Aurora Serverless v2). Eso depende de cuándo el equipo Infra construya y bajo qué presupuesto. Se difiere a un ADR posterior.
+
+## Decisión
+
+1. **Motor**: PostgreSQL.
+2. **Versión local**: PostgreSQL 18.3 (imagen `postgres:18.3-alpine`).
+3. **Definición de schema**: **TypeORM** mediante clases TypeScript decoradas (`@Entity`, `@Column`, etc.) en `Skorify_Data/entities/`.
+4. **Migrations y queries en runtime**: **Knex** (`knex` y `pg`) configurado en `knexfile.js`, con migrations versionadas en `Skorify_Data/migrations/`.
+5. **Soft delete**: campo `deleted_at TIMESTAMP NULL` en tablas que lo requieren (User, Team, Group, Prediction, Instance). La validación es manual en cada servicio (`where deleted_at IS NULL`); **no** se usa `DeleteDateColumn` de TypeORM.
+6. **RBAC**: campo `role VARCHAR` en `User` con valores `general | global | instance`. Implementado como string libre en código, **sin** enum SQL.
+7. **Modelo de empaquetado**: el repo Data se publica como librería npm/pnpm consumible vía Git tag (ver ADR-INFRA-0010). El backend importa `DBClient` y servicios desde esta librería en lugar de definir su propia conexión a la DB.
+8. **Decisión diferida**: motor AWS específico (RDS vs Aurora vs Aurora Serverless v2) y configuración por ambiente. Se documentará en un ADR aparte cuando el equipo Infra construya.
+
+## Consecuencias
+
+### Positivas
+
+- Schema y queries viven en el mismo repo, en TypeScript con tipos completos. Ningún equipo de aplicación duplica la definición de tablas.
+- Knex permite migrations atómicas con rollback nativo, mejor que las migrations propias de TypeORM en proyectos pequeños.
+- TypeORM aporta tipos automáticos sobre las entidades para los consumidores (BE), que pueden importar `User`, `Match`, etc. sin redeclararlas.
+- Patrón de librería consumida vía Git centraliza la fuente de verdad del modelo de datos.
+
+### Negativas / Trade-offs
+
+- **Patrón híbrido TypeORM + Knex es inusual** y no encontrarás muchos ejemplos en la comunidad. La curva de aprendizaje para un nuevo integrante es mayor que adoptar uno solo de los dos.
+- Soft delete manual (sin `DeleteDateColumn`) es propenso a errores: cualquier query nuevo debe acordarse de filtrar `deleted_at IS NULL`. Un olvido devuelve datos borrados.
+- RBAC con string libre (no enum SQL) permite valores inválidos en la columna sin que la base se entere. Validación queda 100% en código.
+- El motor AWS sigue sin definir; cuando Infra construya, hay que volver a este ADR (o crear uno hijo) para decidir RDS vs Aurora.
+
+### Neutrales / Riesgos a monitorear
+
+- Si en el futuro el equipo decide unificar a "solo TypeORM" o "solo Knex", este ADR se reemplazará. Hoy se acepta el híbrido tal como está implementado.
+- Monitorear la integridad del soft delete: si crece a más de 5–6 tablas, considerar promoverlo a un patrón compartido (ej. una utilidad `softDeleteWhere()` o un decorator custom).
+- Considerar añadir un `CHECK constraint` a `User.role` en una migration futura si el RBAC se mantiene como `general | global | instance`.
+
+## Notas adicionales
+
+- Documentación del modelo en `Skorify_Data/docs/DATABASE.md` y diagrama ER en `Skorify_Data/docs/SkorifyDB.png`.
+- Concepto de negocio relevante: `Instance` es una "polla/pool" — grupo privado de usuarios que comparten reglas dentro de un torneo.

--- a/docs/adr/infra/0009-estado-fase0-y-plan-migracion-aws.md
+++ b/docs/adr/infra/0009-estado-fase0-y-plan-migracion-aws.md
@@ -1,0 +1,86 @@
+# ADR-INFRA-0009: Estado fase 0 y plan de migración a AWS
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: Infra
+- **Autores**: @Mateo454 (Mateo Marín)
+- **Aprobadores**: <pendiente> (requiere los 3 líderes — toca el roadmap general de infra)
+
+## Contexto
+
+La auditoría del 2026-04-26 sobre los tres repos de aplicación reveló una brecha grande entre los ADRs target (qué queremos) y la realidad del código (qué hay hoy):
+
+- Los ADRs INFRA-0001, INFRA-0003, INFRA-0004 describen un target de infra AWS con CDK (frontend) + SAM (backend) + S3/CloudFront + Lambda/API Gateway.
+- En realidad: el equipo Infra todavía no ha construido los recursos AWS. Cada repo de aplicación está corriendo en un estado provisional muy distinto al target.
+
+Estado real al 2026-04-26 (referencias verificables):
+
+| Repo | Realidad fase 0 | Target ADR |
+|------|-----------------|-----------|
+| `Skorify_Frontend` | Next.js 16.2.2 sin `output: 'export'`, sin carpeta `infra/`, sin workflows AWS. Despliegue actual: indefinido. | ADR-INFRA-0003 (S3 + CloudFront vía CDK) |
+| `Skorify_Backend` | Node monolítico con framework Iraca (`@scifamek-open-source/iraca/web-api`), corre en puerto 9898 con `nodemon`. SAM template existe solo como generador de código en `builders/`. Workflow `.github/workflows/deploy.yml` solo construye, no despliega. | ADR-INFRA-0004 (Lambda + API Gateway + SAM) |
+| `Skorify_Data` | PostgreSQL local con Docker Compose. Es una librería consumible vía Git tag (`#v1.0.0-beta.2`). Sin AWS. | ADR-INFRA-0008 (Postgres en AWS, motor por definir) |
+
+Los líderes del proyecto confirmaron explícitamente:
+
+- **El backend DEBE correr en Lambda** (acuerdo global).
+- **El frontend NO usará Amplify**: irá a S3 + CloudFront.
+- **El equipo Infra construirá ambos recursos**.
+
+Por tanto los ADRs target no se anulan; lo que falta es un plan explícito que lleve de la realidad (fase 0) al target.
+
+## Decisión
+
+Adoptamos un **modelo de fases** explícito para la migración a AWS. El equipo Infra es dueño de las fases 1 y 2; los equipos de aplicación colaboran en lo que les corresponda.
+
+### Fase 0 — Estado actual (al 2026-04-26)
+
+Aceptamos que el proyecto opera hoy en este estado y que es transitorio:
+
+- Frontend: Next.js corriendo en cualquier despliegue temporal definido por el equipo FE (puede ser local, Vercel temporal, GitHub Pages u otro). Este ADR no fija ningún despliegue temporal — el equipo FE decide cómo demostrar avance mientras Infra construye.
+- Backend: Iraca como monolito Node. Despliegue temporal a definir por BE+Infra (App Runner, EC2, ECS u otra opción de bajo costo) si necesitan demostrar avance antes de la fase 1.
+- Data: Postgres local con Docker Compose; consumido por BE+FE solo en local.
+- Sin OIDC, sin Datadog, sin pipelines de despliegue a AWS.
+
+### Fase 1 — Construcción de infra AWS (owner: equipo Infra)
+
+> **TODO** — completar por @Mateo454 con tiempos y dependencias:
+>
+> Recursos a construir, agrupados por sub-proyecto:
+>
+> - **Frontend**: bucket S3 + CloudFront + ACM (certificado en `us-east-1`) + Route53. CDK en TypeScript dentro del repo `Skorify_Frontend/infra/`.
+> - **Backend**: API Gateway (REST o HTTP API por definir) + función Lambda + IAM roles. SAM en `Skorify_Backend/template.yaml`. Decisión por tomar entre BE+Infra: si Iraca se empaqueta como handler Lambda (vía Lambda Web Adapter o adaptador HTTP) o si BE reescribe handlers nativos.
+> - **Data**: instancia PostgreSQL en AWS (motor RDS vs Aurora vs Aurora Serverless v2 a decidir en ADR posterior). VPC, subnets y SGs según necesidad real.
+> - **Cross-cutting**: OIDC provider GitHub→AWS + IAM roles `skorify-deploy-{env}` (ver ADR-INFRA-0005).
+> - **Pre-requisito FE**: el equipo Frontend activa `output: 'export'` en `next.config.ts` y verifica que ningún feature dependa de SSR/API routes/ISR.
+
+### Fase 2 — Operación y observabilidad
+
+> **TODO** — completar por @Mateo454 + @lmichaelrc:
+>
+> - Datadog integrado (ver ADR-SRE-0001 y -0002).
+> - Pipelines completos en los tres repos (ver ADR-CICD-0001 y siguientes).
+> - SSO/IAM avanzado, KMS, rotación de secretos.
+
+## Consecuencias
+
+### Positivas
+
+- El equipo deja de pretender que la infra ya existe: el plan reconoce la realidad fase 0 y la trata como transitoria.
+- Cada equipo de aplicación sabe qué se espera de él en la fase 1 (FE activa SSG, BE define empaquetado de Iraca, Data prepara migration de local a AWS).
+- Reduce el riesgo de "deuda técnica fantasma": los ADRs target dejan de ser ficción y pasan a ser meta verificable.
+
+### Negativas / Trade-offs
+
+- Documentar la fase 0 puede dar la impresión de que la realidad provisional es aceptable a largo plazo. Mitigación: este ADR debe revisitarse cuando se cierre la fase 1; en ese momento la fase 0 deja de ser "estado actual" y pasa a ser "histórico".
+- El acoplamiento entre BE e Infra (Iraca → Lambda) introduce una decisión técnica no trivial: empaquetar vs reescribir. Cualquiera de las dos tiene costo.
+
+### Neutrales / Riesgos a monitorear
+
+- **Riesgo**: que la fase 0 se prolongue más de lo esperado. Acordar una fecha tentativa para el cierre de fase 1 (no se fija en este ADR; lo define Infra) y revisar mensualmente.
+- **Riesgo**: que cada equipo de aplicación haga decisiones de despliegue temporal divergentes durante la fase 0. Mitigación: cada equipo escribe sus decisiones temporales en su propio repo (no requiere ADR si es transitorio y no afecta a otros equipos), pero las comunica al coordinador para visibilidad.
+
+## Notas adicionales
+
+- Los ADRs INFRA-0001, INFRA-0003 y INFRA-0004 contienen bloques `<!-- NOTA OBSERVADA -->` que enlazan a este ADR.
+- La decisión de motor AWS PostgreSQL (RDS vs Aurora) se difiere a un ADR independiente cuando Infra esté listo para construir.

--- a/docs/adr/infra/0010-skorify-data-como-libreria.md
+++ b/docs/adr/infra/0010-skorify-data-como-libreria.md
@@ -1,0 +1,63 @@
+# ADR-INFRA-0010: Skorify_Data como librería consumida vía Git
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: Infra
+- **Autores**: equipo Data (decisión ya implementada)
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+Históricamente se asumió que `Skorify_Data` sería un servicio o un repo de migrations independiente. La auditoría del 2026-04-26 reveló que el equipo data ya implementó un modelo distinto que conviene formalizar: **el repo Data es una librería npm/pnpm consumida desde otros repos vía Git tag**.
+
+Hechos observados en `Skorify_Data`:
+
+- `package.json` con `"name": "skorifydata"` y configuración de exports.
+- Existe el tag Git `v1.0.0-beta.2` ya publicado.
+- El repo expone `lib/index.ts` que re-exporta `DBClient` (clase) y todas las entidades TypeORM.
+- El subdirectorio `dev-server/` es un servicio Express interno cuya `package.json` instala `skorifydata` como dependencia desde Git, demostrando el patrón de consumo: `pnpm add github:aws-ug-manizales/Skorify_Data#v1.0.0-beta.2`.
+- 15 entidades, servicios y migrations viven dentro de la librería.
+
+Este modelo **no estaba documentado** en ADRs antes de hoy. Formalizarlo permite que:
+
+- El equipo BE consuma la librería con una versión fija y conocida.
+- Los cambios al schema se versionen explícitamente (no son cambios silenciosos en producción).
+- Los reviewers entiendan por qué Data no es un servicio AWS independiente.
+
+## Decisión
+
+1. **Skorify_Data se publica como librería npm/pnpm** consumible vía Git.
+2. **Mecanismo de consumo**: `pnpm add github:aws-ug-manizales/Skorify_Data#<tag>` (o el equivalente con `npm`/`yarn`). Las dependencias `peerDependencies` requeridas (`pg`, `typeorm`, `knex`, etc.) las instala el repo consumidor.
+3. **Versionado**: se usan **Git tags semver** del repo Data como puntos fijos (ej. `v1.0.0-beta.2`, `v1.0.0`, `v1.1.0`). Cada PR a `main` que cambie el schema o la API exportada produce un nuevo tag.
+4. **Consumidores actuales**:
+   - `dev-server/` interno del propio repo Data — para pruebas.
+   - `Skorify_Backend` — consumirá la librería para conectarse a la DB y reutilizar entidades/servicios.
+5. **Consumidores potenciales** (a evaluar caso por caso):
+   - `Skorify_Frontend` — solo si necesita los **tipos** de entidades en cliente. Si solo consume el backend, no necesita la librería.
+6. **Migrations**: las migrations Knex viven en la librería y se ejecutan vía `knex migrate:latest` desde el repo consumidor o desde el propio repo Data según el contexto. El procedimiento exacto se documenta en `Skorify_Data/README.md` (responsabilidad del equipo data).
+
+## Consecuencias
+
+### Positivas
+
+- Una sola fuente de verdad del modelo de datos — no hay duplicación entre BE y FE.
+- Versionado explícito permite que un cambio breaking del schema bloquee a los consumidores hasta que migren.
+- El equipo Data puede iterar en su repo y publicar versiones a su ritmo.
+- Tipos TypeScript completos atraviesan el boundary: el BE recibe `User`, `Match`, etc. con sus tipos derivados de las entidades TypeORM.
+
+### Negativas / Trade-offs
+
+- Instalar desde Git es más lento y menos cacheable que un registro npm privado. Si el ritmo de releases crece, considerar publicar al GitHub Packages npm registry.
+- La librería incluye dependencias pesadas (TypeORM, Knex, pg) que el frontend no necesita; si FE alguna vez la consume, evitar import del runtime y usar solo los tipos (`import type`).
+- Coordinación de migrations: si dos consumidores corren `knex migrate:latest` con versiones distintas de la librería, pueden chocar. La política operativa debe definir quién es el "ejecutor canónico" de migrations en cada ambiente.
+
+### Neutrales / Riesgos a monitorear
+
+- Si en el futuro varios servicios consumen la librería, considerar publicar al **GitHub Packages npm registry** para mejor caching y autenticación granular.
+- Si el equipo FE termina necesitando solo los tipos, exponer un sub-export (`skorifydata/types`) que no arrastre dependencias runtime.
+- Monitorear el peso del bundle si BE termina con dependencias transitivas excesivas.
+
+## Notas adicionales
+
+- Este ADR formaliza una decisión que ya está en código. El estado `Propuesto` indica que falta la firma de los aprobadores; no que la decisión esté en debate.
+- ADR relacionado: ADR-INFRA-0008 (stack PostgreSQL TypeORM + Knex).

--- a/docs/adr/infra/README.md
+++ b/docs/adr/infra/README.md
@@ -1,0 +1,22 @@
+# ADRs — Área Infra
+
+**Líder de área**: Mateo Marín (@Mateo454)
+
+**Alcance**: IaC (CDK frontend, SAM backend), recursos AWS, ambientes, IAM, OIDC, red, KMS, gestión de secretos runtime, cost governance.
+
+> Esta área absorbió responsabilidades de OIDC, IAM, red y KMS al disolverse el área de Seguridad — ver [ADR-0002 general](../0002-redistribucion-responsabilidades-seguridad.md).
+
+## Índice
+
+| ADR | Título | Estado |
+|-----|--------|--------|
+| [0001](./0001-cdk-frontend-sam-backend.md) | CDK para frontend y SAM para backend | Aceptado |
+| [0002](./0002-aislamiento-ambientes-cuenta-unica.md) | Una cuenta AWS con aislamiento por prefijos + IAM + tags | Propuesto |
+| [0003](./0003-frontend-nextjs-ssg-s3-cloudfront.md) | Frontend Next.js SSG en S3 + CloudFront | Propuesto |
+| [0004](./0004-backend-lambda-apigw-typescript.md) | Backend en Lambda + API Gateway + Node.js TypeScript | Propuesto |
+| [0005](./0005-oidc-github-aws.md) | Autenticación GitHub Actions → AWS vía OIDC | Propuesto |
+| [0006](./0006-tagging-naming-aws.md) | Estándar de tagging y naming AWS | Propuesto |
+| [0007](./0007-gestion-secretos.md) | Gestión de secretos: SSM/Secrets Manager para runtime | Propuesto |
+| [0008](./0008-motor-postgresql.md) | Stack PostgreSQL — TypeORM + Knex (decisión del equipo data) | Propuesto |
+| [0009](./0009-estado-fase0-y-plan-migracion-aws.md) | Estado fase 0 y plan de migración a AWS | Propuesto |
+| [0010](./0010-skorify-data-como-libreria.md) | Skorify_Data como librería consumida vía Git | Propuesto |

--- a/docs/adr/sre/0001-datadog-plataforma-observabilidad.md
+++ b/docs/adr/sre/0001-datadog-plataforma-observabilidad.md
@@ -1,0 +1,55 @@
+# ADR-SRE-0001: Datadog como plataforma de observabilidad
+
+- **Estado**: Aceptado
+- **Fecha**: 2026-04-26
+- **Área**: SRE
+- **Autores**: @lmichaelrc (Michael Rivera)
+- **Aprobadores**: @lmichaelrc, @steevensmelo, @Mateo454, @edisoncast
+
+## Contexto
+
+El proyecto Skorify necesita observabilidad sobre tres ambientes que corren en una sola cuenta AWS, con frontend (Next.js SSG en S3+CloudFront), backend (Lambda+API Gateway) y eventualmente data (PostgreSQL). El equipo necesita ver:
+
+- **Logs** estructurados de cada Lambda y de los componentes del frontend.
+- **Métricas** custom y nativas de AWS (latencia API, errores Lambda, costo).
+- **Traces** distribuidos (request entra por API Gateway → Lambda → DB).
+- **Audit logs** de CloudTrail centralizados (responsabilidad absorbida del área de Seguridad).
+
+Opciones evaluadas:
+
+- **Datadog**: plataforma SaaS unificada (logs, metrics, APM, RUM, synthetics, SLOs). Excelente UX, dashboards potentes, integraciones con AWS sin desarrollo custom. Costo recurrente por host/Gb.
+- **AWS CloudWatch + X-Ray**: nativo, sin costo externo significativo (pago por uso AWS), integrado a IAM. Dashboards más rudimentarios, correlación entre componentes manual.
+- **Open Source self-hosted (Grafana + Loki + Tempo + Prometheus)**: flexible, gratis pero requiere infraestructura adicional y operación que el equipo no puede asumir hoy.
+
+El equipo decidió **Datadog** anteponiendo el valor pedagógico (es una herramienta estándar de la industria que los estudiantes encontrarán en su carrera) y la unificación de señales (logs+métricas+traces en una sola UI con correlación automática). La decisión está aceptada; este ADR la formaliza.
+
+## Decisión
+
+Adoptamos **Datadog** como plataforma única de observabilidad para el proyecto Skorify, cubriendo logs, métricas, traces y audit logs (CloudTrail integrado).
+
+Implicaciones:
+
+1. Las Lambdas envían logs y traces a Datadog vía la integración nativa AWS↔Datadog (forwarder Lambda o subscripción de log groups). El método exacto se define en el ADR-SRE-0002.
+2. CloudTrail se integra a Datadog para visibilidad de eventos de seguridad y auditoría.
+3. El frontend reporta errores y eventos a Datadog (RUM) en fase 2 — no MVP.
+4. La cuenta de Datadog y el plan asociado están **pendientes de definir** (ver ADR-SRE-0005). Hasta entonces, el equipo SRE puede prototipar con la cuenta de prueba gratuita.
+
+## Consecuencias
+
+### Positivas
+
+- Una sola UI para todas las señales: reduce el costo cognitivo cuando un estudiante investiga un incidente.
+- Correlación automática logs ↔ traces ↔ métricas vía atributos (`trace_id`, `service`, `env`).
+- Integración con AWS (CloudWatch metric streams, CloudTrail events) sin desarrollo custom.
+- Valor pedagógico: Datadog es referencia en la industria; aprenderlo aporta a la formación de los estudiantes.
+
+### Negativas / Trade-offs
+
+- **Costo recurrente** que hay que financiar (ver ADR-SRE-0005). Si el plan no se asegura, el ADR podría reemplazarse por uno que use CloudWatch como fallback.
+- **Vendor lock-in**: dashboards, alertas y SLOs en Datadog no son trivialmente migrables a otra plataforma. Mitigación: mantener la instrumentación basada en estándares abiertos (OpenTelemetry) cuando sea posible.
+- **Curva de aprendizaje**: configurar tags, índices de logs, monitors y SLOs requiere tiempo. Mitigación: documentar plantillas y patrones en `docs/runbooks/`.
+
+### Neutrales / Riesgos a monitorear
+
+- Volumen de logs y trace ingestion: el costo escala rápido si no se filtran o samplean traces. Establecer presupuestos y alertas de uso desde el día 1.
+- Si el plan elegido (ADR-SRE-0005) tiene límites estrictos, hay que planificar fase 2 (RUM, synthetics) considerando incremento.

--- a/docs/adr/sre/0002-alcance-mvp-fase2.md
+++ b/docs/adr/sre/0002-alcance-mvp-fase2.md
@@ -1,0 +1,48 @@
+# ADR-SRE-0002: Alcance MVP y fase 2 de observabilidad
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: SRE
+- **Autores**: @lmichaelrc
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+Datadog ofrece muchas capacidades (logs, metrics, APM, RUM, synthetics, SLOs, CSM, etc.). Implementar todo de inicio dispersa el esfuerzo del equipo y eleva el costo. Necesitamos priorizar.
+
+Propuesta de alcance MVP (lo que arranca con el proyecto):
+
+- **Logs** estructurados de Lambdas y reactor del frontend (errores).
+- **Métricas** nativas de AWS (Lambda errors/duration, API Gateway latency/4xx/5xx) vía CloudWatch metric streams.
+- **Traces** APM en backend Lambdas (vía Datadog Lambda Layer o DD-Trace).
+- **CloudTrail integrado** a Datadog para audit logs.
+
+Fase 2 (después del MVP, sujeto a éxito y presupuesto):
+
+- **RUM** (Real User Monitoring) en el frontend Next.js.
+- **Synthetics** (uptime checks, browser tests) para detección proactiva de outages.
+- **SLOs** (Service Level Objectives) con error budget tracking.
+- **Chaos engineering** experimental (opcional, pedagógico).
+
+> **TODO** — completar por @lmichaelrc:
+> - Definir métodos exactos de envío (Lambda Layer, forwarder, OpenTelemetry).
+> - Lista de dashboards iniciales mínimos (uno por servicio + uno cross-service).
+> - Criterios para promover capacidades de fase 2 a producción.
+
+## Decisión
+
+<!-- TODO -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->

--- a/docs/adr/sre/0003-logging-estructurado-json.md
+++ b/docs/adr/sre/0003-logging-estructurado-json.md
@@ -1,0 +1,46 @@
+# ADR-SRE-0003: Estrategia de logging estructurado JSON
+
+- **Estado**: Propuesto
+- **Fecha**: 2026-04-26
+- **Área**: SRE
+- **Autores**: @lmichaelrc
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+Logs de texto plano son difíciles de filtrar, agregar y correlacionar. Logs en formato **JSON estructurado** permiten que Datadog (y CloudWatch Logs Insights) parseen automáticamente los campos, faciliten búsquedas por atributos (`service`, `env`, `request_id`) y se correlacionen con traces vía `trace_id`/`span_id`.
+
+Atributos candidatos a estandarizar:
+
+- `timestamp` (ISO 8601 UTC)
+- `level` (`debug`, `info`, `warn`, `error`)
+- `service` (`skorify-frontend`, `skorify-backend`, etc.)
+- `env` (`dev`, `stg`, `prd`)
+- `request_id`, `trace_id`, `span_id`
+- `message` (texto humano)
+- `error.kind`, `error.message`, `error.stack` cuando aplique
+
+> **TODO** — completar por @lmichaelrc:
+> - Elegir librería de logging para Node.js TypeScript (pino, winston, AWS Lambda Powertools).
+> - Convención de campos obligatorios vs opcionales.
+> - Política de **PII / datos sensibles**: qué nunca se loguea, qué se redacta.
+> - Niveles de log activos por ambiente (DEV puede loguear `debug`, PROD solo `info+`).
+> - Política de retención por ambiente y tipo de log.
+
+## Decisión
+
+<!-- TODO -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->

--- a/docs/adr/sre/0004-politica-alertas-on-call.md
+++ b/docs/adr/sre/0004-politica-alertas-on-call.md
@@ -1,0 +1,41 @@
+# ADR-SRE-0004: Política de alertas, severidades y on-call
+
+- **Estado**: Propuesto (fase 2)
+- **Fecha**: 2026-04-26
+- **Área**: SRE
+- **Autores**: @lmichaelrc
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+Una vez que la observabilidad MVP esté capturando señales (ver ADR-SRE-0002), el siguiente paso es definir alertas con criterios claros. Sin política, se cae en alguno de estos extremos:
+
+- Demasiadas alertas → fatiga, ignorar avisos.
+- Pocas alertas → incidentes pasan desapercibidos hasta que un usuario reclama.
+
+Este ADR queda en estado **Propuesto** hasta que el equipo SRE tenga MVP de telemetría operativo. Sin datos reales no podemos calibrar umbrales.
+
+> **TODO** — completar cuando MVP de telemetría esté operativo:
+> - Niveles de severidad (P1/P2/P3) y respuesta esperada por nivel.
+> - Canales de alerta (Slack/Discord, email, PagerDuty) por severidad.
+> - Lista inicial de alertas críticas (errores 5xx > X%, p99 latency > Y, Lambda errors, costos por encima de presupuesto).
+> - Política de on-call: ¿hay turnos en este proyecto comunitario o solo best-effort?
+> - Runbooks por alerta (en `docs/runbooks/`).
+
+## Decisión
+
+<!-- TODO -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->

--- a/docs/adr/sre/0005-plan-billing-datadog.md
+++ b/docs/adr/sre/0005-plan-billing-datadog.md
@@ -1,0 +1,41 @@
+# ADR-SRE-0005: Plan de Datadog y modelo de billing
+
+- **Estado**: Propuesto (bloqueado)
+- **Fecha**: 2026-04-26
+- **Área**: SRE
+- **Autores**: @lmichaelrc
+- **Aprobadores**: <pendiente>
+
+## Contexto
+
+ADR-SRE-0001 adopta Datadog como plataforma de observabilidad. Datadog cobra por host, ingesta de logs, traces y otras dimensiones. Para un proyecto comunitario hay que definir:
+
+- Qué plan se usa (free trial, Pro, Enterprise).
+- Quién paga (sponsor de la comunidad? recursos del User Group? créditos AWS si aplica?).
+- Cuál es el presupuesto mensual aceptable y qué hacemos si se excede.
+
+**Bloqueador**: estos puntos no están definidos. Sin claridad de billing, no podemos comprometer la decisión de Datadog a largo plazo.
+
+> **TODO** — completar cuando se defina el sponsor y presupuesto:
+> - Plan elegido y costo mensual estimado.
+> - Proceso para escalar el plan si el proyecto crece.
+> - Plan de contingencia si el sponsor se retira (¿migración a CloudWatch?).
+> - Quién es el dueño de la cuenta Datadog y los procedimientos de acceso.
+
+## Decisión
+
+<!-- BLOQUEADO: pendiente definición de billing y sponsor -->
+
+## Consecuencias
+
+### Positivas
+
+<!-- TODO -->
+
+### Negativas / Trade-offs
+
+<!-- TODO -->
+
+### Neutrales / Riesgos a monitorear
+
+<!-- TODO -->

--- a/docs/adr/sre/README.md
+++ b/docs/adr/sre/README.md
@@ -1,0 +1,17 @@
+# ADRs — Área SRE
+
+**Líder de área**: Michael Rivera (@lmichaelrc)
+
+**Alcance**: observabilidad (Datadog), logging estructurado, métricas, traces, alertas, audit logging (CloudTrail), runbooks, postmortems.
+
+> Esta área absorbió la responsabilidad de audit logging al disolverse el área de Seguridad — ver [ADR-0002 general](../0002-redistribucion-responsabilidades-seguridad.md).
+
+## Índice
+
+| ADR | Título | Estado |
+|-----|--------|--------|
+| [0001](./0001-datadog-plataforma-observabilidad.md) | Datadog como plataforma de observabilidad | Aceptado |
+| [0002](./0002-alcance-mvp-fase2.md) | Alcance MVP (logs, métricas, traces) y fase 2 (RUM, SLOs, synthetics) | Propuesto |
+| [0003](./0003-logging-estructurado-json.md) | Estrategia de logging estructurado JSON | Propuesto |
+| [0004](./0004-politica-alertas-on-call.md) | Política de alertas, severidades y on-call | Propuesto (fase 2) |
+| [0005](./0005-plan-billing-datadog.md) | Plan de Datadog y modelo de billing | Propuesto (bloqueado) |

--- a/docs/onboarding/backend-repo-setup.md
+++ b/docs/onboarding/backend-repo-setup.md
@@ -1,0 +1,46 @@
+# Onboarding: Skorify_Backend
+
+Guía paso a paso para conectar el repo `Skorify_Backend` a las plantillas centralizadas de `Skorify_DevOps`.
+
+> **Estado**: CASCARÓN. Esta guía describe el procedimiento esperado a alto nivel; los detalles exactos se completan cuando los reusable workflows estén implementados (ver ADR-CICD-0004).
+
+> **Nota fase 0**: las plantillas de despliegue asumen que la infra AWS ya fue construida por el equipo Infra (fase 1 según ADR-INFRA-0009) y que el backend corre en Lambda + API Gateway. Hoy el backend corre como monolito Node con framework Iraca en puerto 9898 — no es aplicable a estas plantillas todavía. Ver `<!-- NOTA OBSERVADA -->` en ADR-INFRA-0004.
+
+## Estado real observado (auditoría 2026-04-26)
+
+- Stack: Node.js + TypeScript + pnpm + arquitectura hexagonal + Jest.
+- Framework HTTP: `@scifamek-open-source/iraca/web-api` (Iraca) — no es API Gateway nativo.
+- SAM template existe solo como GENERADOR de código en `builders/src/single-lambda-aws/templates/`, no como infra desplegable.
+- Workflow existente `.github/workflows/deploy.yml` solo construye, no despliega.
+- Sin ESLint, sin pre-commit, sin Datadog, sin storage AWS conectado.
+- Decisión técnica pendiente: empaquetar Iraca como handler Lambda (vía Lambda Web Adapter) vs reescribir handlers nativos. Ver ADR-INFRA-0009.
+
+## Pre-requisitos
+
+- Permisos de administrador en el repo `aws-ug-manizales/Skorify_Backend`.
+- El repo `Skorify_DevOps` tiene al menos un tag publicado (ej. `v0.1.0`).
+
+## Pasos esperados
+
+1. **Branch protection en `main` y `develop`** — análogo a `Skorify_Frontend`.
+
+2. **GitHub Environments** — `development`, `staging`, `production` con secretos y reviewers.
+
+3. **Workflows wrapper**
+   - `.github/workflows/ci.yml` invocando `backend-ci.yml@vX`.
+   - `.github/workflows/cd-dev.yml`, `cd-staging.yml`, `cd-prod.yml` invocando los respectivos.
+
+4. **Pre-commit**
+   - Copiar `pre-commit/backend.pre-commit-config.yaml` a la raíz del repo como `.pre-commit-config.yaml`.
+
+5. **SAM**
+   - El repo contendrá `template.yaml` y `samconfig.toml` gestionados por el equipo Backend.
+   - Verificar que el proceso de build (`sam build`) está cubierto por la plantilla CI.
+
+6. **CODEOWNERS** del repo.
+
+> **TODO**: completar comandos y snippets cuando reusable workflows existan.
+
+## Quién hace este onboarding
+
+DevOps (idealmente Steevens Castañeda) + alguien del equipo Backend en pareja.

--- a/docs/onboarding/data-repo-setup.md
+++ b/docs/onboarding/data-repo-setup.md
@@ -1,0 +1,36 @@
+# Onboarding: Skorify_Data
+
+Guía para conectar el repo `Skorify_Data` a las plantillas centralizadas de `Skorify_DevOps`.
+
+> **Estado**: DESBLOQUEADO PARCIALMENTE. La auditoría del 2026-04-26 confirmó el stack del repo. Lo que sigue bloqueado es el target de despliegue AWS (depende de fase 1 según ADR-INFRA-0009).
+
+## Stack confirmado tras auditoría
+
+- **Lenguaje**: Node.js + TypeScript
+- **Package manager**: pnpm
+- **Base de datos**: PostgreSQL (TypeORM para entidades + Knex para migrations y queries; ver ADR-INFRA-0008)
+- **Modelo de empaquetado**: librería consumida vía Git tag (`#v1.0.0-beta.2` ya existe; ver ADR-INFRA-0010)
+- **Branching actual**: `main ← staging ← development ← features/*` (3 niveles)
+- **Sin workflows GitHub Actions hoy**, sin tests, sin ESLint configurado
+
+## Pasos esperados (en cuanto se acepten los ADRs relevantes)
+
+1. **Branch protection** en `main`, `staging`, `development` — análogo a los otros repos.
+2. **GitHub Environments** — cuando Infra construya AWS (fase 1).
+3. **Workflows wrapper**
+   - `.github/workflows/ci.yml` invocando `data-ci.yml@vX` cuando el reusable se implemente.
+   - Workflows de despliegue solo aplican una vez que se decida el target AWS de la base de datos (fase 1).
+4. **Pre-commit / hooks**
+   - Adoptar la herramienta que se decida en ADR-CICD-0010 (Husky o framework `pre-commit`).
+   - Hooks de referencia: ESLint, Prettier, commitlint, gitleaks.
+5. **Tests**: el repo no tiene tests hoy. Adoptar Jest o Vitest cuando se prioriice.
+6. **Migrations en producción**: definir en fase 1 quién es el "ejecutor canónico" de `knex migrate:latest` por ambiente. Ver ADR-INFRA-0008.
+
+## Bloqueadores remanentes
+
+- Decisión de motor AWS específico para Postgres (RDS vs Aurora vs Aurora Serverless v2) — depende de fase 1 / ADR-INFRA-0009.
+- Decisión Husky vs `pre-commit` framework — depende de ADR-CICD-0010.
+
+## Quién hace este onboarding
+
+DevOps (Steevens Castañeda) + alguien del equipo Data en pareja.

--- a/docs/onboarding/frontend-repo-setup.md
+++ b/docs/onboarding/frontend-repo-setup.md
@@ -1,0 +1,49 @@
+# Onboarding: Skorify_Frontend
+
+Guía paso a paso para conectar el repo `Skorify_Frontend` a las plantillas centralizadas de `Skorify_DevOps`.
+
+> **Estado**: CASCARÓN. Esta guía describe el procedimiento esperado a alto nivel; los detalles exactos se completan cuando los reusable workflows estén implementados (ver ADR-CICD-0004).
+
+> **Nota fase 0**: las plantillas de despliegue (`cd-dev`, `cd-staging`, `cd-prod`) asumen que la infra AWS ya fue construida por el equipo Infra (fase 1 según ADR-INFRA-0009). Hasta que eso ocurra, los workflows de despliegue no son aplicables — solo el de validación CI tiene sentido.
+
+## Estado real observado (auditoría 2026-04-26)
+
+- Stack: Next.js 16.2.2 + React 19.2.4 + TypeScript.
+- Package manager: **yarn** (la composite action `setup-node-pnpm` deberá ajustarse o crearse una hermana para yarn).
+- Pre-commit: ya usa **Husky + lint-staged** (no `.pre-commit-config.yaml`).
+- `next.config.ts` **no** tiene `output: 'export'` activo — debe activarse antes de desplegar a S3+CloudFront. Ver ADR-INFRA-0003.
+
+## Pre-requisitos
+
+- Permisos de administrador en el repo `aws-ug-manizales/Skorify_Frontend`.
+- El repo `Skorify_DevOps` tiene al menos un tag publicado (ej. `v0.1.0`).
+
+## Pasos esperados
+
+1. **Branch protection en `main` y `develop`**
+   - Activar "Require a pull request before merging".
+   - Mínimo 2 reviewers.
+   - Required status checks (los nombres exactos se definen cuando los workflows existan).
+
+2. **GitHub Environments**
+   - Crear `development`, `staging`, `production`.
+   - En `production`: required reviewers (los líderes definidos en ADR-0003 general).
+   - Configurar secrets necesarios por ambiente (ver ADR-INFRA-0007).
+
+3. **Workflows wrapper**
+   - Crear `.github/workflows/ci.yml` que invoque `aws-ug-manizales/Skorify_DevOps/.github/workflows/frontend-ci.yml@vX`.
+   - Crear `.github/workflows/cd-dev.yml`, `cd-staging.yml`, `cd-prod.yml` con los reusable correspondientes.
+   - Pasar inputs requeridos por las plantillas.
+
+4. **Pre-commit**
+   - Copiar `pre-commit/frontend.pre-commit-config.yaml` de Skorify_DevOps a la raíz del repo como `.pre-commit-config.yaml`.
+   - Documentar `pre-commit install` en el README del repo.
+
+5. **CODEOWNERS**
+   - Crear `CODEOWNERS` con los owners del repo de aplicación.
+
+> **TODO**: completar comandos exactos y snippets cuando los reusable workflows estén implementados.
+
+## Quién hace este onboarding
+
+Según el plan, lo realiza una pareja: alguien del equipo DevOps (idealmente Steevens Castañeda) + alguien del equipo Frontend, con valor pedagógico para los estudiantes.

--- a/pre-commit/backend.pre-commit-config.yaml
+++ b/pre-commit/backend.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+# =============================================================================
+# Configuración de pre-commit para Skorify_Backend
+# Owner: equipo CI/CD — @steevensmelo
+# Estado: CASCARÓN — pendiente de implementación
+#
+# ATENCIÓN: ver ADR-CICD-0010 (Husky vs framework `pre-commit`). La elección
+# de herramienta no está cerrada. BE no tiene ningún hook hoy.
+# =============================================================================
+#
+# Referencia:
+# - ADR-CICD-0007 (pre-commit hooks por tipo de proyecto)
+#
+# Hooks esperados (cuando se implemente):
+# - hooks comunes: gitleaks, commitlint, trailing-whitespace, end-of-file-fixer
+# - específicos BE: eslint, prettier, tsc --noEmit
+# - si se editan plantillas SAM: cfn-lint o equivalente
+
+repos: []
+# TODO: declarar repos de hooks

--- a/pre-commit/data.pre-commit-config.yaml
+++ b/pre-commit/data.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+# =============================================================================
+# Configuración de pre-commit para Skorify_Data
+# Owner: equipo CI/CD — @steevensmelo
+# Estado: CASCARÓN — DESBLOQUEADO (stack confirmado por auditoría 2026-04-26)
+# =============================================================================
+#
+# Stack confirmado tras auditoría: Skorify_Data es Node.js + TypeScript + pnpm
+# (no Python). Referencia: ADR-INFRA-0008.
+#
+# ATENCIÓN: ver ADR-CICD-0010 (Husky vs framework `pre-commit`). La elección
+# de herramienta no está cerrada. Data no tiene ningún hook hoy.
+#
+# Hooks esperados cuando se implemente (ESLint+Prettier+commitlint+gitleaks
+# si se elige Husky/lint-staged; o equivalentes si se elige `pre-commit`).
+
+repos: []
+# TODO: implementar hooks (mismos que backend dado que stack es Node + TypeScript)

--- a/pre-commit/frontend.pre-commit-config.yaml
+++ b/pre-commit/frontend.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+# =============================================================================
+# Configuración de pre-commit para Skorify_Frontend
+# Owner: equipo CI/CD — @steevensmelo
+# Estado: CASCARÓN — pendiente de implementación
+#
+# ATENCIÓN: hay una decisión cruzada pendiente en ADR-CICD-0010
+# (Husky vs framework `pre-commit`). Skorify_Frontend YA usa Husky + lint-staged
+# con reglas en su `package.json`. Si el equipo elige Husky como estándar,
+# este archivo se elimina y la guía apunta al setup de Husky en cada repo.
+# Si se elige `pre-commit` framework, el equipo FE tendrá que migrar.
+# Hasta que el ADR se cierre, este archivo queda como cascarón.
+# =============================================================================
+#
+# Referencia:
+# - ADR-CICD-0007 (pre-commit hooks por tipo de proyecto)
+# - https://pre-commit.com (documentación de la herramienta)
+#
+# Hooks esperados (cuando se implemente):
+# - hooks comunes: gitleaks, commitlint, trailing-whitespace, end-of-file-fixer
+# - específicos FE: eslint, prettier, tsc --noEmit
+#
+# Una vez implementado, el repo Skorify_Frontend lo copia a su raíz como
+# .pre-commit-config.yaml o lo extiende con `extends:` si la herramienta lo
+# permite.
+
+repos: []
+# TODO: declarar repos de hooks


### PR DESCRIPTION
## Descripcion                                                                                                                                 
                                                                                                                                                 
  Construye sobre la estructura inicial creada por @steevensmelo (commit 15288b9):                                                               
   
  - **32 ADRs** en formato Nygard (espanol) repartidos en general (4), CI/CD (10), Infra (10) y SRE (5). Cada area tiene su README indice. ADRs  
  target en estado `Aceptado`; el resto en `Propuesto` con contexto pre-cargado para que cada lider redacte la decision y consecuencias.
  - **3 ADRs nuevos** que la auditoria de los repos de aplicacion (2026-04-26) hizo evidentes: ADR-INFRA-0009 (estado fase 0 + plan de migracion 
  AWS), ADR-INFRA-0010 (Skorify_Data como libreria), ADR-CICD-0010 (Husky vs framework pre-commit).                                              
  - **3 guias de onboarding** (`docs/onboarding/{frontend,backend,data}-repo-setup.md`) con el estado real observado en cada repo y los pasos 
  esperados.                                                                                                                                     
  - **Composite actions** rellenadas en `actions/` (run-trivy, run-eslint, notify-slack, setup-node, setup-aws-credentials).
  - **Self-validation workflow** cascaron para CI del propio repo central.                                                                       
  - **Pre-commit configs** cascaron, pendientes de la decision del ADR-CICD-0010.                                                                
  - **README enriquecido** con seccion de equipo, ADRs y convencion de commits.                                                                  
  - **CODEOWNERS lleno** con los handles de los lideres por carpeta.                                                                             
  - **LICENSE** MIT.                                                                                                                             
  - **Directorios `sre/` y `scripts/`** con .gitkeep para que la estructura coincida con el README.                                              
                                                                                                                                                 
  Importante: este PR **no decide** nada que conflictue con el modelo de @steevensmelo. Adopta su estructura (workflows por stage-componente, 
  composite actions en `actions/` raiz, IaC en `iac/`) y la complementa con la documentacion de decisiones que faltaba.                          
                                                            
  ## Tipo de cambio                                                                                                                              
                                                            
  - [x] Nuevo workflow / action
  - [x] Documentacion general                                                                                                                    
  - [x] Nuevo ADR o cambio en ADR existente
                                                                                                                                                 
  ## Si es un ADR                                           
                                                                                                                                                 
  Se introducen 32 ADRs. Los target (en estado `Aceptado`) son:
  - ADR-0001 (proceso), ADR-0002 (redistribucion seguridad), ADR-0003 (estructura equipo)                                                        
  - ADR-CICD-0001 (GitHub Actions), ADR-INFRA-0001 (CDK FE + SAM BE), ADR-SRE-0001 (Datadog)                                                     
                                                                                                                                                 
  ADRs sensibles que tocan IAM/OIDC/red/secretos → requieren los 3 lideres:                                                                      
  - ADR-INFRA-0005 (OIDC), ADR-INFRA-0007 (gestion de secretos)                                                                                  
                                                                                                                                                 
  ## Impacto                                                                                                                                     
                                                                                                                                                 
  - [x] Frontend (onboarding y notas observadas)            
  - [x] Backend (onboarding y notas observadas)                                                                                                  
  - [x] Datos (onboarding desbloqueado tras auditoria)                                                                                           
  - [x] Infraestructura transversal (catalogo de ADRs Infra)                                                                                     
                                                                                                                                                 
  ## Aprobadores requeridos                                                                                                                      
                                                                                                                                                 
  - [x] @steevensmelo (CI/CD)                               
  - [x] @Mateo454 (Infra)                                                                                                                        
  - [x] @lmichaelrc (SRE)
  - [x] @edisoncast (coordinacion general)                                                                                                       
                                                                                                                                                 
  ## Checklist                                                                                                                                   
                                                                                                                                                 
  - [x] El titulo del PR sigue Conventional Commits         
  - [x] El contenido esta en espanol
  - [x] Cada ADR esta incluido en el indice del area correspondiente                                                                             
  - [x] Los 9 commits del PR siguen Conventional Commits y agrupan por intencion                                                                 
  - [x] Ningun ADR menciona Amplify (queda fuera de alcance por decision del proyecto)                                                           
  - [x] Ninguna afirmacion inventa: cada hallazgo cita rutas reales de los repos auditados                                                       
                                                                                                                                                 
  ## Commits incluidos                                                                                                                           
                                                                                                                                                 
  d0b2c35 docs: guias de onboarding por repo de aplicacion  
  6229f76 chore: cascarones de configuracion de pre-commit                                                                                       
  3b0294a ci: composite actions y workflow de self-validation
  93baca1 docs(adr/sre): catalogo inicial de ADRs del area SRE                                                                                   
  890f052 docs(adr/infra): catalogo inicial de ADRs del area Infra                                                                               
  57fca58 docs(adr/ci-cd): catalogo inicial de ADRs del area CI/CD
  08e4b9d docs(adr): redistribucion de seguridad y estructura del equipo                                                                         
  1f1dc58 docs(adr): adopcion del formato Nygard y proceso de ADRs      
  442239b chore: complementar archivos base del repo                                          