### PR TITLE
Add setup-node action with Yarn caching

### DIFF
--- a/actions/setup-node/action.yml
+++ b/actions/setup-node/action.yml
@@ -1,0 +1,41 @@
+name: 'Setup Node.js with Cache'
+description: 'Configura Node.js, instala dependencias y configura caché para Yarn'
+
+inputs:
+  node-version:
+    description: 'Versión de Node.js a usar'
+    required: false
+    default: '18'
+  working-directory:
+    description: 'Directorio donde está el package.json'
+    required: false
+    default: '.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: 'yarn'
+        cache-dependency-path: ${{ inputs.working-directory }}/yarn.lock
+    
+    - name: Get yarn cache directory
+      id: yarn-cache-dir
+      shell: bash
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      working-directory: ${{ inputs.working-directory }}
+    
+    - name: Cache yarn dependencies
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.yarn-cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles(format('{0}/yarn.lock', inputs.working-directory)) }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+    
+    - name: Install dependencies
+      shell: bash
+      run: yarn install --frozen-lockfile
+      working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
## Descripcion

Se crea la accion personalizada `setup-node` que configura Node.js, instala dependencias y configura cache para Yarn.

**Caracteristicas:**
- Permite especificar version de Node.js (default: 18)
- Permite especificar directorio de trabajo (default: .)
- Cache automatico de dependencias Yarn usando `actions/cache`
- Instalacion con `yarn install --frozen-lockfile` para consistencia

**Beneficios:**
- Reduce tiempo de ejecucion de workflows (cache)
- Estandariza la configuracion de Node.js en todos los proyectos
- Elimina codigo repetido en los workflows

## Tipo de cambio

- [x] Nuevo workflow / action
- [ ] Modificacion de workflow / action existente
- [ ] Cambio de infraestructura (IaC)
- [ ] Runbook / documentacion SRE
- [ ] Script operativo
- [ ] Documentacion general

## Impacto

- [x] Frontend
- [x] Backend
- [ ] Datos
- [ ] Infraestructura transversal

## Checklist

- [x] He probado los cambios localmente o en un ambiente de prueba
- [x] La documentacion relevante ha sido actualizada
- [x] Los workflows modificados siguen la convencion de nombrado `stage--componente.yml`
- [x] No se exponen secrets ni credenciales en el codigo

## Evidencia

**Prueba local:**
```yaml
# Test realizado con:
uses: ./actions/setup-node
with:
  node-version: '20'
  working-directory: './backend'
