### PR TITLE
Se implementa la capa de networking privada del proyecto en AWS.

### DIFF
--- a/lib/config/networking-env.ts
+++ b/lib/config/networking-env.ts
@@ -1,0 +1,11 @@
+import { VpcModuleProps } from '../modules/vpc/main';
+
+export const getVpcModulePropsFromEnv = (env: NodeJS.ProcessEnv = process.env): VpcModuleProps => {
+  const { SKORIFY_VPC_NAME, SKORIFY_VPC_CIDR, SKORIFY_PRIVATE_SUBNET_CIDRS } = env;
+  if (!SKORIFY_VPC_NAME || !SKORIFY_VPC_CIDR) throw new Error('Missing SKORIFY_VPC_NAME or SKORIFY_VPC_CIDR');
+  return {
+    vpcName: SKORIFY_VPC_NAME,
+    cidr: SKORIFY_VPC_CIDR,
+    privateSubnetCidrs: SKORIFY_PRIVATE_SUBNET_CIDRS?.split(',').map((x) => x.trim()).filter((x) => x.length > 0),
+  };
+};

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -2,12 +2,15 @@
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { loadConfigFromSSM } from './config/ssm-reader';
+import { getVpcModulePropsFromEnv } from './config/networking-env';
 import { S3Module } from './modules/s3/main';
+import { VpcModule } from './modules/vpc/main';
 import { maybeCreateSkorifyOrganizationStack } from './modules/organizations/stack';
 import { maybeCreateSkorifyBootstrapStack } from './modules/iam/oidc-and-roles/stack';
 
 const app = new cdk.App();
 const environmentName = process.env.SKORIFY_ENVIRONMENT ?? 'dev';
+const enableNetworking = (process.env.SKORIFY_ENABLE_NETWORKING ?? 'true').toLowerCase() === 'true';
 
 // ==========================================
 // Skorify CDK App: configuración desde Parameter Store
@@ -58,6 +61,15 @@ if (config.s3Buckets.length > 0) {
   new S3Module(envStack, 'S3Storage', {
     buckets: config.s3Buckets,
   });
+}
+/**
+ * Módulo de VPC: parámetros de red para la VPC privada.
+ * 
+ * Inicializa la red privada base (VPC, subnets y rutas) para que otros módulos desplieguen recursos internos.
+ * 
+ */
+if (enableNetworking) {
+  new VpcModule(envStack, 'Network', getVpcModulePropsFromEnv());
 }
 
 // ==========================================

--- a/lib/modules/vpc/main.ts
+++ b/lib/modules/vpc/main.ts
@@ -1,0 +1,114 @@
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { Fn } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+
+export interface VpcModuleProps {
+  /** Nombre de la VPC en AWS (tag Name). */
+  readonly vpcName: string;
+
+  /** CIDR principal de la VPC. */
+  readonly cidr: string;
+
+  /** CIDRs de las 3 subnets privadas. */
+  readonly privateSubnetCidrs?: string[];
+}
+
+/**
+ * Modulo de networking privado.
+ *
+ * Crea una VPC sin NAT ni Internet Gateway, con 3 subnets privadas,
+ * 3 route tables privadas y asociaciones entre subnets y rutas.
+ */
+export class VpcModule extends Construct {
+  /** Referencia reutilizable de la VPC para otros módulos/stacks. */
+  public readonly vpc: ec2.IVpc;
+
+  /** Lista de subnets privadas creadas por el módulo. */
+  public readonly privateSubnets: ec2.ISubnet[];
+
+  /**
+   * Construye el networking base del entorno.
+   *
+   * Flujo general:
+   * 1. Valida que existan exactamente 3 CIDRs de subnets privadas.
+   * 2. Resuelve dinámicamente 3 Availability Zones.
+   * 3. Crea una VPC sin recursos públicos (sin NAT/IGW).
+   * 4. Crea una subnet privada por AZ.
+   * 5. Crea una route table privada por subnet.
+   * 6. Asocia cada subnet a su route table correspondiente.
+   * 7. Expone referencias tipadas (IVpc/ISubnet[]) para reutilización.
+   *
+   * @param scope Construct padre donde vive el módulo.
+   * @param id Identificador lógico del módulo dentro del scope.
+   * @param props Parámetros de red (nombre de VPC, CIDR y subnets privadas).
+   */
+  constructor(scope: Construct, id: string, props: VpcModuleProps) {
+    super(scope, id);
+
+    // Si no se reciben subnets por props, se usa el baseline de 3 /24 privados.
+    const subnetCidrs = props.privateSubnetCidrs ?? ['10.0.1.0/24', '10.0.2.0/24', '10.0.3.0/24'];
+
+    // Guard clause: este módulo exige 3 subnets privadas para mantener el diseño estándar.
+    if (subnetCidrs.length !== 3) {
+      throw new Error('[VpcModule] Debes definir exactamente 3 CIDRs para privateSubnetCidrs.');
+    }
+
+    // Asigna una AZ por subnet para distribuir recursos de forma balanceada.
+    const availabilityZones = subnetCidrs.map((_, index) => Fn.select(index, Fn.getAzs()));
+
+    // VPC base privada con DNS habilitado para resolución interna.
+    const cfnVpc = new ec2.CfnVPC(this, 'MainVpc', {
+      cidrBlock: props.cidr,
+      enableDnsHostnames: true,
+      enableDnsSupport: true,
+      tags: [{ key: 'Name', value: props.vpcName }],
+    });
+
+    // Crea 3 subnets privadas (una por AZ) y aplica tags consistentes por ambiente.
+    const privateSubnetResources = subnetCidrs.map(
+      (subnetCidr, index) =>
+        new ec2.CfnSubnet(this, `PrivateSubnet${index + 1}`, {
+          vpcId: cfnVpc.ref,
+          cidrBlock: subnetCidr,
+          availabilityZone: availabilityZones[index],
+          mapPublicIpOnLaunch: false,
+          tags: [{ key: 'Name', value: `${props.vpcName}-private-${index + 1}` }],
+        }),
+    );
+
+    // Crea una route table dedicada por subnet para aislar rutas por segmento.
+    const routeTableResources = privateSubnetResources.map(
+      (_, index) =>
+        new ec2.CfnRouteTable(this, `PrivateRouteTable${index + 1}`, {
+          vpcId: cfnVpc.ref,
+          tags: [{ key: 'Name', value: `${props.vpcName}-rt-private-${index + 1}` }],
+        }),
+    );
+
+    // Relaciona 1:1 cada subnet con su route table privada.
+    privateSubnetResources.forEach((subnet, index) => {
+      new ec2.CfnSubnetRouteTableAssociation(this, `PrivateSubnetAssociation${index + 1}`, {
+        subnetId: subnet.ref,
+        routeTableId: routeTableResources[index].ref,
+      });
+    });
+
+    // Expone subnets como ISubnet para consumo desde otros módulos sin acoplarse a Cfn*.
+    this.privateSubnets = privateSubnetResources.map((subnet, index) =>
+      ec2.Subnet.fromSubnetAttributes(this, `PrivateSubnetRef${index + 1}`, {
+        subnetId: subnet.ref,
+        availabilityZone: availabilityZones[index],
+        routeTableId: routeTableResources[index].ref,
+      }),
+    );
+
+    // Expone la VPC como IVpc para que otros módulos puedan adjuntar recursos de red.
+    this.vpc = ec2.Vpc.fromVpcAttributes(this, 'MainVpcRef', {
+      vpcId: cfnVpc.ref,
+      vpcCidrBlock: props.cidr,
+      availabilityZones,
+      privateSubnetIds: privateSubnetResources.map((subnet) => subnet.ref),
+      privateSubnetRouteTableIds: routeTableResources.map((routeTable) => routeTable.ref),
+    });
+  }
+}


### PR DESCRIPTION
La solución crea una VPC con DNS habilitado, 3 subredes privadas distribuidas en distintas zonas de disponibilidad, sus tablas de rutas dedicadas y las asociaciones correspondientes entre subred y tabla. No se exponen recursos públicos ni salida directa a internet, manteniendo un diseño seguro y orientado a cargas internas. Además, se exponen referencias reutilizables de la VPC y subredes para que otros módulos de infraestructura puedan consumir esta red de forma consistente.

## Descripcion

Crea una VPC con DNS habilitado, 3 subredes privadas distribuidas en distintas zonas de disponibilidad, sus tablas de rutas dedicadas y las asociaciones correspondientes entre subred y tabla. No se exponen recursos públicos ni salida directa a internet, manteniendo un diseño seguro y orientado a cargas internas. Además, se exponen referencias reutilizables de la VPC y subredes para que otros módulos de infraestructura puedan consumir esta red de forma consistente.

## Tipo de cambio

- [ ] Nuevo workflow / action
- [ ] Modificacion de workflow / action existente
- [X] Cambio de infraestructura (IaC)
- [ ] Runbook / documentacion SRE
- [ ] Script operativo
- [ ] Nuevo ADR o cambio en ADR existente
- [ ] Documentacion general

## Si es un ADR

- **Numero y titulo**: ADR-XXXX —
- **Area**: CI/CD | Infra | SRE | General
- **Estado propuesto**: Propuesto | Aceptado
- **Reemplaza a**: (si aplica) ADR-YYYY
- **Toca IAM, OIDC, red, secretos o audit logs?**: Si / No
  - Si si, requiere review de los **tres lideres de area**

## Impacto

<!-- Indica qué repositorios o ambientes se ven afectados -->

- [ ] Frontend
- [ ] Backend
- [ ] Datos
- [X] Infraestructura transversal

## Checklist

- [X] He probado los cambios localmente o en un ambiente de prueba
- [ ] La documentacion relevante ha sido actualizada
- [ ] Los workflows modificados siguen la convencion de nombrado `stage-componente.yml`
- [X] No se exponen secrets ni credenciales en el codigo
- [ ] (Si es ADR) Esta incluido en el indice del area correspondiente
